### PR TITLE
update histogram

### DIFF
--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -66,7 +66,7 @@ fn main() {
                 .set(ContentType(encoder.format_type().parse::<Mime>().unwrap()));
             res.send(&buffer).unwrap();
 
-            HTTP_REQ_HISTOGRAM.observe_duration(start.elapsed());
+            HTTP_REQ_HISTOGRAM.observe(start.elapsed());
             HTTP_BODY_GAUGE.set(buffer.len() as f64);
         })
         .unwrap();

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -66,8 +66,7 @@ fn main() {
                 .set(ContentType(encoder.format_type().parse::<Mime>().unwrap()));
             res.send(&buffer).unwrap();
 
-            let spend = (start.elapsed().subsec_nanos() as f64) / 1e6;
-            HTTP_REQ_HISTOGRAM.observe(spend);
+            HTTP_REQ_HISTOGRAM.observe_duration(start.elapsed());
             HTTP_BODY_GAUGE.set(buffer.len() as f64);
         })
         .unwrap();

--- a/src/encoder.rs
+++ b/src/encoder.rs
@@ -310,7 +310,7 @@ test_untyped{a="1",b="2"} 2
     fn test_text_encoder_histogram() {
         let opts = HistogramOpts::new("test_histogram", "test help").const_label("a", "1");
         let histogram = Histogram::with_opts(opts).unwrap();
-        histogram.observe(0.25);
+        histogram.observe_seconds(0.25);
 
         let mf = histogram.collect();
         let mut writer = Vec::<u8>::new();

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -247,13 +247,13 @@ impl Histogram {
 }
 
 impl Histogram {
-    /// `observe` adds a single observation (with seconds) to the `Histogram`.
-    pub fn observe(&self, v: f64) {
+    /// `observe_seconds` adds a single observation (with seconds) to the `Histogram`.
+    pub fn observe_seconds(&self, v: f64) {
         self.core.write().unwrap().observe(v)
     }
 
-    /// `observe_duration` adds a single observation (with Duration) to the `Histogram`.
-    pub fn observe_duration(&self, d: Duration) {
+    /// `observe` adds a single observation (with Duration) to the `Histogram`.
+    pub fn observe(&self, d: Duration) {
         let v = duration_to_seconds(d);
         self.core.write().unwrap().observe(v)
     }
@@ -383,23 +383,7 @@ pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> Result<Vec<
     Ok(buckets)
 }
 
-/// Convert Duration to seconds.
-///
-/// # Examples
-///
-/// ```
-/// use std::time::Duration;
-/// use std::f64::EPSILON;
-///
-/// use prometheus::duration_to_seconds;
-///
-/// let tbls = vec![(1000, 1.0), (1100, 1.1), (100111, 100.111)];
-/// for (millis, seconds) in tbls {
-///     let d = Duration::from_millis(millis);
-///     let v = duration_to_seconds(d);
-///     assert!((v - seconds).abs() < EPSILON);
-/// }
-/// ```
+/// `duration_to_seconds` converts Duration to seconds.
 pub fn duration_to_seconds(d: Duration) -> f64 {
     let nanos = d.subsec_nanos() as f64 / 1e9;
     d.as_secs() as f64 + nanos
@@ -420,8 +404,8 @@ mod tests {
             .const_label("a", "1")
             .const_label("b", "2");
         let histogram = Histogram::with_opts(opts).unwrap();
-        histogram.observe(0.5);
-        histogram.observe_duration(Duration::from_secs(1));
+        histogram.observe_seconds(0.5);
+        histogram.observe(Duration::from_secs(1));
 
         let mf = histogram.collect();
         let m = mf.get_metric().as_ref().get(0).unwrap();
@@ -477,6 +461,16 @@ mod tests {
             if got.is_ok() {
                 assert_eq!(got.unwrap(), vec);
             }
+        }
+    }
+
+    #[test]
+    fn test_duration_to_seconds() {
+        let tbls = vec![(1000, 1.0), (1100, 1.1), (100111, 100.111)];
+        for (millis, seconds) in tbls {
+            let d = Duration::from_millis(millis);
+            let v = duration_to_seconds(d);
+            assert!((v - seconds).abs() < EPSILON);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use self::histogram::{Histogram, HistogramVec, HistogramOpts};
 
 // Functions
 pub use self::registry::{gather, register, unregister};
-pub use self::histogram::{linear_buckets, exponential_buckets, duration_to_seconds};
+pub use self::histogram::{linear_buckets, exponential_buckets};
 
 // Constants
 pub use self::encoder::TEXT_FORMAT;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use self::histogram::{Histogram, HistogramVec, HistogramOpts};
 
 // Functions
 pub use self::registry::{gather, register, unregister};
-pub use self::histogram::{linear_buckets, exponential_buckets};
+pub use self::histogram::{linear_buckets, exponential_buckets, duration_to_seconds};
 
 // Constants
 pub use self::encoder::TEXT_FORMAT;


### PR DESCRIPTION
@overvenus 

Hi @brian-brazil 
I think in Rust, the Histogram observe should use Duration which will be more easily used, because Duration doesn't support the function like go Duration `Seconds()`.
Most of the cases, we may use like:

```
let t = Instant::now();
// do something
histogram.observe(t.elapsed()); 
```