### PR TITLE
validate metric and label names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ fnv = "1.0.3"
 lazy_static = "0.2.1"
 libc = "0.2"
 hyper = "0.9"
+regex = "0.1"
 
 [dev-dependencies]
 getopts = "0.2.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,6 @@ extern crate fnv;
 extern crate lazy_static;
 extern crate hyper;
 extern crate libc;
-#[macro_use]
 extern crate regex;
 
 mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ extern crate fnv;
 extern crate lazy_static;
 extern crate hyper;
 extern crate libc;
+#[macro_use]
+extern crate regex;
 
 mod errors;
 mod encoder;


### PR DESCRIPTION
The regexes are copied from the Go client libraries; Go and the regex
crate both use RE2 syntax.