### PR TITLE
bench: add gauge and histogram benchmarks

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -17,3 +17,5 @@ extern crate test;
 extern crate prometheus;
 
 mod counter;
+mod gauge;
+mod histogram;

--- a/benches/gauge.rs
+++ b/benches/gauge.rs
@@ -1,0 +1,30 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use test::Bencher;
+
+use prometheus::{Opts, Gauge, GaugeVec};
+
+#[bench]
+fn bench_gauge_with_label_values(b: &mut Bencher) {
+    let gauge = GaugeVec::new(Opts::new("benchmark_gauge", "A gauge to benchmark it."),
+                              &["one", "two", "three"])
+        .unwrap();
+    b.iter(|| gauge.with_label_values(&["eins", "zwei", "drei"]).inc())
+}
+
+#[bench]
+fn bench_gauge_no_labels(b: &mut Bencher) {
+    let gauge = Gauge::new("benchmark_gauge", "A gauge to benchmark it.").unwrap();
+    b.iter(|| gauge.inc())
+}

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -1,0 +1,41 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use test::Bencher;
+
+use prometheus::{HistogramOpts, Histogram, HistogramVec};
+
+#[bench]
+fn bench_histogram_with_label_values(b: &mut Bencher) {
+    let histogram = HistogramVec::new(HistogramOpts::new("benchmark_histogram",
+                                                         "A histogram to benchmark it."),
+                                      &["one", "two", "three"])
+        .unwrap();
+    b.iter(|| histogram.with_label_values(&["eins", "zwei", "drei"]).observe(3.1415))
+}
+
+#[bench]
+fn bench_histogram_no_labels(b: &mut Bencher) {
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram",
+                                                            "A histogram to benchmark it."))
+        .unwrap();
+    b.iter(|| histogram.observe(3.1415))
+}
+
+#[bench]
+fn bench_histogram_timer(b: &mut Bencher) {
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
+                                                            "A histogram to benchmark it."))
+        .unwrap();
+    b.iter(|| histogram.start_timer())
+}


### PR DESCRIPTION
Report:

```
test counter::bench_counter_no_labels                   ... bench:          44 ns/iter (+/- 2)
test counter::bench_counter_with_label_values           ... bench:         136 ns/iter (+/- 4)
test counter::bench_counter_with_mapped_labels          ... bench:         400 ns/iter (+/- 44)
test counter::bench_counter_with_prepared_mapped_labels ... bench:         250 ns/iter (+/- 4)
test gauge::bench_gauge_no_labels                       ... bench:          43 ns/iter (+/- 1)
test gauge::bench_gauge_with_label_values               ... bench:         131 ns/iter (+/- 7)
test histogram::bench_histogram_no_labels               ... bench:          52 ns/iter (+/- 12)
test histogram::bench_histogram_timer                   ... bench:         265 ns/iter (+/- 14)
test histogram::bench_histogram_with_label_values       ... bench:         568 ns/iter (+/- 22
```

I will port more benches later.

cc #25 