### PR TITLE
push: make clippy happy

### DIFF
--- a/src/push.rs
+++ b/src/push.rs
@@ -154,7 +154,7 @@ fn push_from_collector(job: &str,
                        method: &str)
                        -> Result<()> {
     let registry = Registry::new();
-    for bc in collectors.into_iter() {
+    for bc in collectors {
         try!(registry.register(bc));
     }
 


### PR DESCRIPTION
Clippy warns:

```
error: it is more idiomatic to loop over `collectors` instead of `collectors.into_iter()` [-D explicit-into-iter-loop]
   --> src/push.rs:157:5
    |
157 |     for bc in collectors.into_iter() {
    |     ^
    |
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#explicit_into_iter_loop
error: aborting due to previous error
```