### PR TITLE
registry: fix panic 'attempt to add with overflow'

### DIFF
--- a/src/registry.rs
+++ b/src/registry.rs
@@ -17,6 +17,7 @@ use std::iter::FromIterator;
 use std::collections::{HashMap, BTreeMap, HashSet};
 use std::collections::btree_map::Entry as BEntry;
 use std::collections::hash_map::Entry as HEntry;
+use std::num::Wrapping;
 
 use proto;
 use metrics::Collector;
@@ -58,7 +59,7 @@ impl RegistryCore {
             // the collector_id.
             if desc_id_set.insert(desc.id) {
                 // The set did not have this value present, true is returned.
-                collector_id ^= desc.id;
+                collector_id = (Wrapping(collector_id) + Wrapping(desc.id)).0;
             } else {
                 // The set did have this value present, false is returned.
                 //
@@ -400,7 +401,7 @@ mod tests {
         ];
 
         let descs = counters.iter()
-            .map(|c| c.desc().into_iter().map(|d| d.clone()))
+            .map(|c| c.desc().into_iter().cloned())
             .fold(Vec::new(), |mut acc, ds| {
                 acc.extend(ds);
                 acc

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -58,7 +58,7 @@ impl RegistryCore {
             // the collector_id.
             if desc_id_set.insert(desc.id) {
                 // The set did not have this value present, true is returned.
-                collector_id += desc.id;
+                collector_id ^= desc.id;
             } else {
                 // The set did have this value present, false is returned.
                 //
@@ -253,7 +253,9 @@ mod tests {
     use std::collections::HashMap;
 
     use counter::{Counter, CounterVec};
-    use metrics::Opts;
+    use metrics::{Opts, Collector};
+    use desc::Desc;
+    use proto;
 
     use super::*;
 
@@ -366,5 +368,50 @@ mod tests {
         assert_eq!(ms[1].get_counter().get_value() as u64, 1);
         assert_eq!(ms[2].get_counter().get_value() as u64, 3);
         assert_eq!(ms[3].get_counter().get_value() as u64, 4);
+    }
+
+    struct MultipleCollector {
+        descs: Vec<Desc>,
+        counters: Vec<Counter>,
+    }
+
+    impl Collector for MultipleCollector {
+        fn desc(&self) -> Vec<&Desc> {
+            self.descs.iter().collect()
+        }
+
+        fn collect(&self) -> Vec<proto::MetricFamily> {
+            self.counters
+                .iter()
+                .inspect(|c| c.inc())
+                .map(|c| c.collect())
+                .fold(Vec::new(), |mut acc, mfs| {
+                    acc.extend(mfs);
+                    acc
+                })
+        }
+    }
+
+    #[test]
+    fn test_register_multiplecollector() {
+        let counters = vec![
+            Counter::new("c1", "c1 is a counter").unwrap(),
+            Counter::new("c2", "c2 is a counter").unwrap(),
+        ];
+
+        let descs = counters.iter()
+            .map(|c| c.desc().into_iter().map(|d| d.clone()))
+            .fold(Vec::new(), |mut acc, ds| {
+                acc.extend(ds);
+                acc
+            });
+
+        let mc = MultipleCollector {
+            descs: descs,
+            counters: counters,
+        };
+
+        let r = Registry::new();
+        r.register(Box::new(mc)).unwrap();
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -17,7 +17,6 @@ use std::iter::FromIterator;
 use std::collections::{HashMap, BTreeMap, HashSet};
 use std::collections::btree_map::Entry as BEntry;
 use std::collections::hash_map::Entry as HEntry;
-use std::num::Wrapping;
 
 use proto;
 use metrics::Collector;
@@ -32,7 +31,7 @@ struct RegistryCore {
 impl RegistryCore {
     fn register(&mut self, c: Box<Collector>) -> Result<()> {
         let mut desc_id_set = HashSet::new();
-        let mut collector_id = 0;
+        let mut collector_id: u64 = 0;
 
         for desc in c.desc() {
             // Is the desc_id unique?
@@ -59,7 +58,7 @@ impl RegistryCore {
             // the collector_id.
             if desc_id_set.insert(desc.id) {
                 // The set did not have this value present, true is returned.
-                collector_id = (Wrapping(collector_id) + Wrapping(desc.id)).0;
+                collector_id = collector_id.wrapping_add(desc.id);
             } else {
                 // The set did have this value present, false is returned.
                 //


### PR DESCRIPTION
When we register a collector that returns multiple descriptors, registry will panic and leaves a message:

> panicked at 'attempt to add with overflow', src/registry.rs:61

[Integer overflow] is considered unsafe in rust. Rust checks it at both [compile time and runtime].

Although there are several ways to workaround, like [scoped-attributes] and [wrapping], ~~I would recommend [xor]. I think xor is enough in our use case.~~

Now, wrapping add.

PTAL @siddontang @disksing 

[xor]: https://doc.rust-lang.org/std/ops/trait.BitXor.html
[wrapping]: https://github.com/rust-lang/rust/issues/22020
[scoped-attributes]: https://github.com/rust-lang/rfcs/blob/master/text/0560-integer-overflow.md#scoped-attributes-to-control-runtime-checking
[compile time and runtime]: https://github.com/rust-lang/rfcs/blob/master/text/0560-integer-overflow.md
[Integer overflow]: https://doc.rust-lang.org/reference.html#behavior-not-considered-unsafe