### PR TITLE
Process collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ env:
 
 script:
   - cargo test
+  - cargo test --features="process"
 
 matrix:
   include:
   - rust: nightly
     script:
-      - cargo test --features="dev nightly process"
+      - cargo test --features="dev nightly"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: rust
 
+os:
+ - linux
+ - osx
+
 rust:
   - stable
   - beta

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   # Script to test 32-bit versions.
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
   # Tests again with features enabled.
-  - export CARGOOPTS=--features="'$FEATURES'"
+  - export CARGOOPTS=--features=\"$FEATURES\"
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ matrix:
   include:
   - rust: nightly
     script:
-      - cargo test --features="dev nightly"
+      - cargo test --features="dev nightly process"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ script:
   # Script to test 32-bit versions.
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
   # Tests again with features enabled.
-  - export CARGOOPTS=--features=\"$FEATURES\"
-  - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
+  # TODO: This is a workaround for testing multiple features.
+  #       Bash incorrectly escapes `--features=\"$FEATURES\"` to `'--features="push' 'process"'`
+  #       See more: https://travis-ci.org/pingcap/rust-prometheus/jobs/175653505#L413
+  - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/df450e9556b1d732399b8a56f396eec14d9d88bd/test | sed 's/\$CARGOOPTS/--features\ \"\$FEATURES\"/' | bash
 
 matrix:
   # TODO: Figure out weridness with `ARCH` being set twice.

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
 env:
   global:
     - RUSTFLAGS=--deny=warnings
-    - FEATURES=push
+    - FEATURES="push process"
   matrix:
     - ARCH=x86_64
     - ARCH=i686
@@ -32,7 +32,7 @@ script:
   # Script to test 32-bit versions.
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
   # Tests again with features enabled.
-  - export CARGOOPTS=--features="$FEATURES"
+  - export CARGOOPTS=--features="'$FEATURES'"
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
 
 matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = []
 dev = ["clippy"]
 nightly = []
 push = ["hyper", "libc"]
-process = ["libc"]
+process = ["libc", "procinfo"]
 
 [[bench]]
 name = "benches"
@@ -30,6 +30,7 @@ clippy = {version = "^0", optional = true}
 fnv = "1.0.3"
 lazy_static = "0.2.1"
 libc = {version = "0.2", optional = true}
+procinfo = {version = "0.3", optional = true}
 
 [dependencies.hyper]
 version = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ clippy = {version = "^0", optional = true}
 fnv = "1.0.3"
 lazy_static = "0.2.1"
 libc = {version = "0.2", optional = true}
+cfg-if = "0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
 procinfo = {version = "0.3", optional = true}
 
 [dependencies.hyper]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = [
 default = []
 dev = ["clippy"]
 nightly = []
-process = ["procinfo"]
+process = []
 
 [[bench]]
 name = "benches"
@@ -30,7 +30,6 @@ fnv = "1.0.3"
 lazy_static = "0.2.1"
 libc = "0.2"
 regex = "0.1"
-procinfo = {version = "0.2", optional = true}
 
 [dependencies.hyper]
 version = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ fnv = "1.0.3"
 lazy_static = "0.2.1"
 libc = "0.2"
 regex = "0.1"
+procinfo = "0.2"
 
 [dependencies.hyper]
 version = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 default = []
 dev = ["clippy"]
 nightly = []
+process = ["procinfo"]
 
 [[bench]]
 name = "benches"
@@ -29,7 +30,7 @@ fnv = "1.0.3"
 lazy_static = "0.2.1"
 libc = "0.2"
 regex = "0.1"
-procinfo = "0.2"
+procinfo = {version = "0.2", optional = true}
 
 [dependencies.hyper]
 version = "0.9"

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
+ENABLE_FEATURES ?= default
+
 all: format build test examples
 
 build:
-	cargo build --features default
+	cargo build --features ENABLE_FEATURES
 
 test:
-	cargo test --features="push" -- --nocapture
+	cargo test --features="${ENABLE_FEATURES}" -- --nocapture
 
 dev: format
-	cargo test --features="push nightly dev" -- --nocapture
+	cargo test --features="${ENABLE_FEATURES} dev" -- --nocapture
 
 bench: format
-	cargo bench --features dev -- --nocapture
+	cargo bench --features=${ENABLE_FEATURES} -- --nocapture
 
 format:
 	@( cargo fmt -- --write-mode diff > /dev/null || cargo fmt -- --write-mode overwrite ) && \

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,7 @@ clean:
 examples:
 	cargo build --example example_embed
 	cargo build --example example_hyper
+	cargo build --example example_push
+	cargo build --features="process" --example example_process_collector
 
 .PHONY: all examples

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -19,7 +19,7 @@ mod process {
     use std::thread;
     use std::time::Duration;
 
-    use prometheus::{self, process_collector, Encoder};
+    use prometheus::{self, Encoder};
 
     pub fn demo() {
         // A default ProcessCollector is registered automatically.

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -22,7 +22,7 @@ mod process {
     use prometheus::{self, process_collector, Encoder};
 
     pub fn demo() {
-        // A default ProcessCollector registers automatically.
+        // A default ProcessCollector is registered automatically.
 
         let mut buffer = Vec::new();
         let encoder = prometheus::TextEncoder::new();

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -1,0 +1,39 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[macro_use]
+extern crate prometheus;
+
+use std::thread;
+use std::time::Duration;
+
+use prometheus::{process_collector, Encoder};
+
+fn main() {
+    let pid = process_collector::get_pid();
+    let pc = process_collector::ProcessCollector::new(pid, "example_process_collector");
+    prometheus::register(Box::new(pc)).unwrap();
+
+    let mut buffer = Vec::new();
+    let encoder = prometheus::TextEncoder::new();
+    for _ in 0..5 {
+        let metric_familys = prometheus::gather();
+        encoder.encode(&metric_familys, &mut buffer).unwrap();
+
+        // Output to the standard output.
+        println!("{}", String::from_utf8(buffer.clone()).unwrap());
+
+        buffer.clear();
+        thread::sleep(Duration::from_secs(1));
+    }
+}

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -22,9 +22,7 @@ mod process {
     use prometheus::{self, process_collector, Encoder};
 
     pub fn demo() {
-        let pid = process_collector::get_pid();
-        let pc = process_collector::ProcessCollector::new(pid, "example_process_collector");
-        prometheus::register(Box::new(pc)).unwrap();
+        // A default ProcessCollector registers automatically.
 
         let mut buffer = Vec::new();
         let encoder = prometheus::TextEncoder::new();

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -14,16 +14,16 @@
 #[macro_use]
 extern crate prometheus;
 
-#[cfg(feature = "process")]
-mod process {
-    use std::thread;
-    use std::time::Duration;
+mod bridge {
 
-    use prometheus::{self, Encoder};
-
+    #[cfg(feature = "process")]
     pub fn demo() {
-        // A default ProcessCollector is registered automatically.
+        use std::thread;
+        use std::time::Duration;
 
+        use prometheus::{self, Encoder};
+
+        // A default ProcessCollector is registered automatically.
         let mut buffer = Vec::new();
         let encoder = prometheus::TextEncoder::new();
         for _ in 0..5 {
@@ -37,16 +37,15 @@ mod process {
             thread::sleep(Duration::from_secs(1));
         }
     }
-}
 
-#[cfg(not(feature = "process"))]
-mod process {
+    #[cfg(not(feature = "process"))]
     pub fn demo() {
         println!("Please enable feature \"process\", then try:\n\tcargo run \
                   --features=\"process\" --example example_process_collector");
     }
+
 }
 
 fn main() {
-    process::demo();
+    bridge::demo();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,12 @@ mod vec;
 mod histogram;
 mod push;
 mod atomic64;
-mod process_collector;
 
 // Mods
 
 /// Protocol buffers format of metrics.
 pub mod proto;
+pub mod process_collector;
 
 // Traits
 pub use self::encoder::Encoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ extern crate lazy_static;
 extern crate hyper;
 extern crate libc;
 extern crate regex;
+#[cfg(feature = "process")]
 extern crate procinfo;
 
 mod errors;
@@ -49,6 +50,7 @@ mod atomic64;
 
 /// Protocol buffers format of metrics.
 pub mod proto;
+#[cfg(feature = "process")]
 pub mod process_collector;
 
 // Traits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ extern crate lazy_static;
 extern crate hyper;
 extern crate libc;
 extern crate regex;
+extern crate procinfo;
 
 mod errors;
 mod encoder;
@@ -43,6 +44,7 @@ mod vec;
 mod histogram;
 mod push;
 mod atomic64;
+mod process_collector;
 
 // Mods
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,10 @@ extern crate fnv;
 extern crate lazy_static;
 #[cfg(feature="push")]
 extern crate hyper;
-#[cfg(feature="push")]
+#[cfg(any(feature="push", feature="process"))]
 extern crate libc;
+#[cfg(all(feature = "process", target_os="linux"))]
+extern crate procinfo;
 
 mod errors;
 mod encoder;
@@ -50,7 +52,7 @@ mod atomic64;
 
 /// Protocol buffers format of metrics.
 pub mod proto;
-#[cfg(feature = "process")]
+#[cfg(all(feature = "process", target_os="linux"))]
 pub mod process_collector;
 
 // Traits

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,6 @@ extern crate lazy_static;
 extern crate hyper;
 extern crate libc;
 extern crate regex;
-#[cfg(feature = "process")]
-extern crate procinfo;
 
 mod errors;
 mod encoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ extern crate hyper;
 extern crate libc;
 #[cfg(all(feature = "process", target_os="linux"))]
 extern crate procinfo;
+#[macro_use]
+extern crate cfg_if;
 
 mod errors;
 mod encoder;

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -259,18 +259,15 @@ fn time_status(pid: pid_t) -> Result<(f64, f64)> {
 
     // cpu
     let mut cpu_time = 0.0;
-    match (status[UTIME_INDEX].parse::<f64>(), status[STIME_INDEX].parse::<f64>()) {
-        (Ok(utime), Ok(stime)) => {
-            cpu_time = (utime + stime) / *CLK_TCK;
-        }
-        _ => (),
+    if let (Ok(utime), Ok(stime)) = (status[UTIME_INDEX].parse::<f64>(),
+                                     status[STIME_INDEX].parse::<f64>()) {
+        cpu_time = (utime + stime) / *CLK_TCK;
     }
 
     // proc_start_time
     let mut start_time = 0.0;
-    match (status[START_TIME_INDEX].parse::<f64>(), *BOOT_TIME) {
-        (Ok(start), Some(boot_time)) => start_time = start / *CLK_TCK + boot_time,
-        _ => (),
+    if let (Ok(start), Some(boot_time)) = (status[START_TIME_INDEX].parse::<f64>(), *BOOT_TIME) {
+        start_time = start / *CLK_TCK + boot_time
     }
 
     Ok((cpu_time, start_time))

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -1,0 +1,128 @@
+// Copyright 2016 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use procinfo::pid;
+use libc::{self, pid_t};
+
+use proto;
+use errors::Result;
+use desc::Desc;
+use metrics::{Opts, Collector};
+use counter::{Counter, CounterVec};
+use gauge::{Gauge, GaugeVec};
+use registry::Registry;
+
+pub struct ProcessCollector {
+    descs: Vec<Desc>,
+    counters: Vec<Counter>,
+    gauges: Vec<Gauge>,
+}
+
+impl ProcessCollector {
+    pub fn new<S: Into<String>>(pid: pid_t, namespace: S) -> ProcessCollector {
+        let namespace = namespace.into();
+        let mut counters = Vec::new();
+        let mut gauges = Vec::new();
+
+        let cpu_total = Counter::with_opts(Opts::new("process_cpu_seconds_total",
+                                                     "Total user and system CPU time spent in \
+                                                      seconds.")
+                .namespace(namespace.as_str()))
+            .unwrap();
+        counters.push(cpu_total);
+
+        let open_fds = Gauge::with_opts(Opts::new("process_open_fds",
+                                                  "Number of open file descriptors.")
+                .namespace(namespace.as_str()))
+            .unwrap();
+        gauges.push(open_fds);
+
+        let max_fds = Gauge::with_opts(Opts::new("process_max_fds",
+                                                 "Maximum number of open file descriptors.")
+                .namespace(namespace.as_str()))
+            .unwrap();
+        gauges.push(max_fds);
+
+        let vsize = Gauge::with_opts(Opts::new("process_virtual_memory_bytes",
+                                               "Virtual memory size in bytes.")
+                .namespace(namespace.as_str()))
+            .unwrap();
+        gauges.push(vsize);
+
+        let rss = Gauge::with_opts(Opts::new("process_resident_memory_bytes",
+                                             "Resident memory size in bytes.")
+                .namespace(namespace.as_str()))
+            .unwrap();
+        gauges.push(rss);
+
+        let start_time = Gauge::with_opts(Opts::new("process_start_time_seconds",
+                                                    "Start time of the process since unix epoch \
+                                                     in seconds.")
+                .namespace(namespace.as_str()))
+            .unwrap();
+        gauges.push(start_time);
+
+        let mut descs = Vec::new();
+        for c in &counters {
+            for d in c.desc().into_iter().cloned() {
+                descs.push(d);
+            }
+        }
+
+        for g in &gauges {
+            for d in g.desc().into_iter().cloned() {
+                descs.push(d);
+            }
+        }
+
+        ProcessCollector {
+            descs: descs,
+            counters: counters,
+            gauges: gauges,
+        }
+    }
+}
+
+impl Collector for ProcessCollector {
+    /// `desc` returns descriptors for metrics.
+    fn desc(&self) -> Vec<&Desc> {
+        self.descs.iter().collect()
+    }
+
+    /// `collect` collects metrics.
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        // FIXME: collect process info.
+        unimplemented!();
+
+        // collect MetricFamilys.
+        let mut mfs = Vec::new();
+        for c in &self.counters {
+            for mf in c.collect() {
+                mfs.push(mf.clone());
+            }
+        }
+
+        for g in &self.gauges {
+            for mf in g.collect() {
+                mfs.push(mf.clone());
+            }
+        }
+
+        mfs
+    }
+}
+
+/// getpid() returns the process ID of the calling process.
+pub fn get_pid() -> pid_t {
+    unsafe { libc::getpid() }
+}

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -11,84 +11,82 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fs;
+use std::path::Path;
+
 use procinfo::pid;
 use libc::{self, pid_t};
 
 use proto;
-use errors::Result;
 use desc::Desc;
 use metrics::{Opts, Collector};
-use counter::{Counter, CounterVec};
-use gauge::{Gauge, GaugeVec};
-use registry::Registry;
+use counter::Counter;
+use gauge::Gauge;
+use errors::Result;
 
 pub struct ProcessCollector {
+    pid: pid_t,
     descs: Vec<Desc>,
-    counters: Vec<Counter>,
-    gauges: Vec<Gauge>,
+    cpu_total: Counter,
+    open_fds: Gauge,
+    max_fds: Gauge,
+    vsize: Gauge,
+    rss: Gauge,
+    start_time: Gauge,
 }
 
 impl ProcessCollector {
     pub fn new<S: Into<String>>(pid: pid_t, namespace: S) -> ProcessCollector {
         let namespace = namespace.into();
-        let mut counters = Vec::new();
-        let mut gauges = Vec::new();
+        let mut descs = Vec::new();
 
         let cpu_total = Counter::with_opts(Opts::new("process_cpu_seconds_total",
                                                      "Total user and system CPU time spent in \
                                                       seconds.")
                 .namespace(namespace.as_str()))
             .unwrap();
-        counters.push(cpu_total);
+        descs.extend(cpu_total.desc().into_iter().cloned());
 
         let open_fds = Gauge::with_opts(Opts::new("process_open_fds",
                                                   "Number of open file descriptors.")
                 .namespace(namespace.as_str()))
             .unwrap();
-        gauges.push(open_fds);
+        descs.extend(open_fds.desc().into_iter().cloned());
 
         let max_fds = Gauge::with_opts(Opts::new("process_max_fds",
                                                  "Maximum number of open file descriptors.")
                 .namespace(namespace.as_str()))
             .unwrap();
-        gauges.push(max_fds);
+        descs.extend(max_fds.desc().into_iter().cloned());
 
         let vsize = Gauge::with_opts(Opts::new("process_virtual_memory_bytes",
                                                "Virtual memory size in bytes.")
                 .namespace(namespace.as_str()))
             .unwrap();
-        gauges.push(vsize);
+        descs.extend(vsize.desc().into_iter().cloned());
 
         let rss = Gauge::with_opts(Opts::new("process_resident_memory_bytes",
                                              "Resident memory size in bytes.")
                 .namespace(namespace.as_str()))
             .unwrap();
-        gauges.push(rss);
+        descs.extend(rss.desc().into_iter().cloned());
 
         let start_time = Gauge::with_opts(Opts::new("process_start_time_seconds",
                                                     "Start time of the process since unix epoch \
                                                      in seconds.")
                 .namespace(namespace.as_str()))
             .unwrap();
-        gauges.push(start_time);
-
-        let mut descs = Vec::new();
-        for c in &counters {
-            for d in c.desc().into_iter().cloned() {
-                descs.push(d);
-            }
-        }
-
-        for g in &gauges {
-            for d in g.desc().into_iter().cloned() {
-                descs.push(d);
-            }
-        }
+        descs.extend(start_time.desc().into_iter().cloned());
 
         ProcessCollector {
+            pid: pid,
             descs: descs,
-            counters: counters,
-            gauges: gauges,
+            cpu_total: cpu_total,
+            open_fds: open_fds,
+            max_fds: max_fds,
+            vsize: vsize,
+            rss: rss,
+            start_time: start_time,
         }
     }
 }
@@ -102,22 +100,25 @@ impl Collector for ProcessCollector {
     /// `collect` collects metrics.
     fn collect(&self) -> Vec<proto::MetricFamily> {
         // FIXME: collect process info.
-        unimplemented!();
+
+        // fds
+        if let Ok(num) = open_fds_num(self.pid) {
+            self.open_fds.set(num as f64);
+        }
+
+        if let Ok(statm) = pid::statm(self.pid) {
+            self.vsize.set(statm.size as f64);
+            self.rss.set(statm.resident as f64)
+        }
 
         // collect MetricFamilys.
         let mut mfs = Vec::new();
-        for c in &self.counters {
-            for mf in c.collect() {
-                mfs.push(mf.clone());
-            }
-        }
-
-        for g in &self.gauges {
-            for mf in g.collect() {
-                mfs.push(mf.clone());
-            }
-        }
-
+        mfs.extend(self.cpu_total.collect());
+        mfs.extend(self.open_fds.collect());
+        mfs.extend(self.max_fds.collect());
+        mfs.extend(self.vsize.collect());
+        mfs.extend(self.rss.collect());
+        mfs.extend(self.start_time.collect());
         mfs
     }
 }
@@ -125,4 +126,17 @@ impl Collector for ProcessCollector {
 /// getpid() returns the process ID of the calling process.
 pub fn get_pid() -> pid_t {
     unsafe { libc::getpid() }
+}
+
+fn open_fds_num(pid: pid_t) -> Result<usize> {
+    // FIXME: path
+    try!(fs::read_dir("./")).fold(Ok(0), |acc, i| {
+        let mut acc = try!(acc);
+
+        if !i.unwrap().file_type().unwrap().is_dir() {
+            acc += 1;
+        }
+
+        Ok(acc)
+    })
 }

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -209,6 +209,7 @@ fn find_statistic(all: &str, pat: &str) -> Result<f64> {
 
 }
 
+// See more `man 5 proc`, `/proc/[pid]/limits`
 const MAX_FD_PATTERN: &'static str = "Max open files";
 
 fn max_fds(pid: pid_t) -> Result<f64> {
@@ -220,6 +221,8 @@ fn max_fds(pid: pid_t) -> Result<f64> {
 
 // 1 KB = 1024 Byte
 const KB_TO_BYTE: f64 = 1024.0;
+
+// See more `man 5 proc`, `/proc/[pid]/status`
 const VM_SIZE_PATTERN: &'static str = "VmSize:";
 const VM_RSS_PATTERN: &'static str = "VmRSS:";
 
@@ -273,6 +276,8 @@ fn time_status(pid: pid_t) -> Result<(f64, f64)> {
     Ok((cpu_time, start_time))
 }
 
+
+// See more `man 5 proc`, `/proc/stat`
 const BOOT_TIME_PATTERN: &'static str = "btime";
 
 lazy_static! {

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -179,8 +179,8 @@ fn open_fds(pid: pid_t) -> Result<usize> {
     })
 }
 
-// `find_statistic` match lines in pattern pat, it takes the first matching line,
-// and parse the first number literal in the matching line.
+// `find_statistic` matches lines in pattern pat, it takes the first matching line,
+// and parses the first number literal in the matching line.
 //
 // Example:
 //  * all:
@@ -197,19 +197,16 @@ fn open_fds(pid: pid_t) -> Result<usize> {
 //
 // pub for tests.
 pub fn find_statistic(all: &str, pat: &str) -> Result<f64> {
-    let literal = all.lines()
-        .find(|line| line.contains(pat))
-        .and_then(|line| {
-            (&line[pat.len()..line.len()])
-                .split_whitespace()
-                .find(|s| !s.is_empty())
-        });
-    match literal {
-        Some(literal) => {
-            literal.parse().map_err(|e| Error::Msg(format!("read statistic {} failed: {}", pat, e)))
+    for line in all.lines() {
+        let kv: Vec<&str> = line.split_whitespace().collect();
+        if kv.len() >= 2 && kv[0].contains(pat) {
+            return kv[1]
+                .parse()
+                .map_err(|e| Error::Msg(format!("read statistic {} failed: {}", pat, e)));
         }
-        None => Err(Error::Msg(format!("read statistic {} failed", pat))),
     }
+
+    Err(Error::Msg(format!("read statistic {} failed", pat)))
 }
 
 fn max_fds(pid: pid_t) -> Result<f64> {

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -19,8 +19,8 @@ use std::fs;
 use std::io::Read;
 use std::sync::Mutex;
 
+use libc;
 use procinfo::pid as pid_info;
-use libc::{self, pid_t};
 
 use proto;
 use desc::Desc;
@@ -28,6 +28,9 @@ use metrics::{Opts, Collector};
 use counter::Counter;
 use gauge::Gauge;
 use errors::{Error, Result};
+
+/// The `pid_t` data type represents process IDs.
+pub use libc::pid_t;
 
 /// `ProcessCollector` a collector which exports the current state of
 /// process metrics including cpu, memory and file descriptor usage as well as
@@ -155,9 +158,12 @@ impl Collector for ProcessCollector {
     }
 }
 
-/// getpid returns the process ID of the calling process.
-pub fn get_pid() -> pid_t {
-    unsafe { libc::getpid() }
+impl Default for ProcessCollector {
+    /// Returns a `ProcessCollector` of the calling process.
+    fn default() -> Self {
+        let pid = unsafe { libc::getpid() };
+        ProcessCollector::new(pid, "")
+    }
 }
 
 fn open_fds(pid: pid_t) -> Result<usize> {

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use std::fs;
-use std::path::Path;
 
 use procinfo::pid;
 use libc::{self, pid_t};
@@ -129,8 +128,8 @@ pub fn get_pid() -> pid_t {
 }
 
 fn open_fds_num(pid: pid_t) -> Result<usize> {
-    // FIXME: path
-    try!(fs::read_dir("./")).fold(Ok(0), |acc, i| {
+    let path = format!("/proc/{}/fd", pid);
+    try!(fs::read_dir(path)).fold(Ok(0), |acc, i| {
         let mut acc = try!(acc);
 
         if !i.unwrap().file_type().unwrap().is_dir() {

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -12,8 +12,10 @@
 // limitations under the License.
 
 use std::fs;
+use std::io::Read;
+use std::sync::Mutex;
 
-use procinfo::pid;
+use procinfo::pid as Pid;
 use libc::{self, pid_t};
 
 use proto;
@@ -21,12 +23,12 @@ use desc::Desc;
 use metrics::{Opts, Collector};
 use counter::Counter;
 use gauge::Gauge;
-use errors::Result;
+use errors::{Error, Result};
 
 pub struct ProcessCollector {
     pid: pid_t,
     descs: Vec<Desc>,
-    cpu_total: Counter,
+    cpu_total: Mutex<Counter>,
     open_fds: Gauge,
     max_fds: Gauge,
     vsize: Gauge,
@@ -80,7 +82,7 @@ impl ProcessCollector {
         ProcessCollector {
             pid: pid,
             descs: descs,
-            cpu_total: cpu_total,
+            cpu_total: Mutex::new(cpu_total),
             open_fds: open_fds,
             max_fds: max_fds,
             vsize: vsize,
@@ -98,21 +100,42 @@ impl Collector for ProcessCollector {
 
     /// `collect` collects metrics.
     fn collect(&self) -> Vec<proto::MetricFamily> {
-        // FIXME: collect process info.
-
-        // fds
-        if let Ok(num) = open_fds_num(self.pid) {
+        // file descriptors
+        if let Ok(num) = open_fds(self.pid) {
             self.open_fds.set(num as f64);
         }
+        if let Ok(max) = max_fds(self.pid) {
+            self.max_fds.set(max)
+        }
 
-        if let Ok(statm) = pid::statm(self.pid) {
-            self.vsize.set(statm.size as f64);
-            self.rss.set(statm.resident as f64)
+        // memory
+        if let Ok((vm_size, vm_rss)) = mem_status(self.pid) {
+            self.vsize.set(vm_size);
+            self.rss.set(vm_rss);
+        }
+
+        // cpu
+        let cpu_total_mfs = {
+            let cpu_total = self.cpu_total.lock().unwrap();
+            if let Ok(total) = total_cpu_sec(self.pid) {
+                let past = cpu_total.get();
+                let delta = total - past;
+                if delta > 0.0 {
+                    cpu_total.inc_by(delta).unwrap();
+                }
+            }
+
+            cpu_total.collect()
+        };
+
+        // start time
+        if let Ok(start_time) = proc_start_time(self.pid) {
+            self.start_time.set(start_time);
         }
 
         // collect MetricFamilys.
         let mut mfs = Vec::new();
-        mfs.extend(self.cpu_total.collect());
+        mfs.extend(cpu_total_mfs);
         mfs.extend(self.open_fds.collect());
         mfs.extend(self.max_fds.collect());
         mfs.extend(self.vsize.collect());
@@ -127,7 +150,8 @@ pub fn get_pid() -> pid_t {
     unsafe { libc::getpid() }
 }
 
-fn open_fds_num(pid: pid_t) -> Result<usize> {
+fn open_fds(pid: pid_t) -> Result<usize> {
+    // FIXME: linux only?
     let path = format!("/proc/{}/fd", pid);
     try!(fs::read_dir(path)).fold(Ok(0), |acc, i| {
         let mut acc = try!(acc);
@@ -138,4 +162,113 @@ fn open_fds_num(pid: pid_t) -> Result<usize> {
 
         Ok(acc)
     })
+}
+
+fn find_in_lines<'a>(all: &'a str, pat: &str) -> Option<&'a str> {
+    all.lines()
+        .find(|line| line.contains(pat))
+        .and_then(|line| Some(&line[pat.len()..line.len()]))
+}
+
+const MAX_FD_PATTERN: &'static str = "Max open files";
+
+fn max_fds(pid: pid_t) -> Result<f64> {
+    let path = format!("/proc/{}/limits", pid);
+    let mut buffer = String::new();
+    try!(fs::File::open(path).and_then(|mut f| f.read_to_string(&mut buffer)));
+    buffer.lines()
+        .find(|line| line.contains(MAX_FD_PATTERN))
+        .and_then(|line| {
+            (&line[MAX_FD_PATTERN.len()..line.len()])
+                .split(char::is_whitespace)
+                .filter(|s| !s.is_empty())
+                .next()
+                .and_then(|max| max.parse().ok())
+        })
+        .ok_or(Error::Msg("read max open files failed".to_owned()))
+}
+
+const VM_SIZE_PATTERN: &'static str = "VmSize:";
+const VM_RSS_PATTERN: &'static str = "VmRSS:";
+const KB_TO_BYTE: f64 = 1024.0; // 1 KB = 1024 Byte
+
+fn mem_status(pid: pid_t) -> Result<(f64, f64)> {
+    let path = format!("/proc/{}/status", pid);
+    let mut buffer = String::new();
+    try!(fs::File::open(path).and_then(|mut f| f.read_to_string(&mut buffer)));
+
+    let vm_size: f64 = try!(buffer.lines()
+        .find(|line| line.contains(VM_SIZE_PATTERN))
+        .and_then(|line| {
+            (&line[VM_SIZE_PATTERN.len()..line.len()])
+                .split(char::is_whitespace)
+                .filter(|s| !s.is_empty())
+                .next()
+                .and_then(|size| size.parse().ok())
+        })
+        .ok_or(Error::Msg("read virtual memory size failed".to_owned())));
+
+    let vm_rss: f64 = try!(buffer.lines()
+        .find(|line| line.contains(VM_RSS_PATTERN))
+        .and_then(|line| {
+            (&line[VM_RSS_PATTERN.len()..line.len()])
+                .split(char::is_whitespace)
+                .filter(|s| !s.is_empty())
+                .next()
+                .and_then(|size| size.parse().ok())
+        })
+        .ok_or(Error::Msg("read resident set size failed".to_owned())));
+
+    Ok((vm_size * KB_TO_BYTE, vm_rss * KB_TO_BYTE))
+}
+
+// This module only supports linux platform. It is safe to
+// retrieve USER_HZ value via a sysconf call.
+lazy_static! {
+    static ref CLK_TCK: f64 = {
+        unsafe {
+            libc::sysconf(libc::_SC_CLK_TCK) as f64
+        }
+    };
+}
+
+fn total_cpu_sec(pid: pid_t) -> Result<f64> {
+    let stat = try!(Pid::stat(pid));
+    Ok((stat.utime + stat.stime) as f64 / *CLK_TCK)
+}
+
+
+const BOOT_TIME_PATTERN: &'static str = "btime";
+
+lazy_static! {
+    static ref BOOT_TIME: Option<f64> = {
+        unsafe {
+            let mut info = ::std::mem::zeroed();
+            match libc::sysinfo(&mut info) {
+                0 => {
+                    let mut buffer = String::new();
+                    if let Err(_) = fs::File::open("/proc/stat")
+                                            .and_then(|mut f| f.read_to_string(&mut buffer))
+                    {
+                        return None;
+                    }
+                    buffer.lines()
+                        .find(|line| line.contains(BOOT_TIME_PATTERN))
+                        .and_then(|line| {
+                            (&line[BOOT_TIME_PATTERN.len()..line.len()])
+                                .split(char::is_whitespace)
+                                .filter(|s| !s.is_empty())
+                                .next()
+                                .and_then(|time| time.parse().ok())
+                        })
+                }
+                _ => None,
+            }
+        }
+    };
+}
+
+fn proc_start_time(pid: pid_t) -> Result<f64> {
+    let stat = try!(Pid::stat(pid));
+    Ok((stat.start_time as f64) / *CLK_TCK + BOOT_TIME.unwrap())
 }

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -54,38 +54,38 @@ impl ProcessCollector {
         let cpu_total = Counter::with_opts(Opts::new("process_cpu_seconds_total",
                                                      "Total user and system CPU time spent in \
                                                       seconds.")
-                .namespace(namespace.as_str()))
+                .namespace(namespace.clone()))
             .unwrap();
         descs.extend(cpu_total.desc().into_iter().cloned());
 
         let open_fds = Gauge::with_opts(Opts::new("process_open_fds",
                                                   "Number of open file descriptors.")
-                .namespace(namespace.as_str()))
+                .namespace(namespace.clone()))
             .unwrap();
         descs.extend(open_fds.desc().into_iter().cloned());
 
         let max_fds = Gauge::with_opts(Opts::new("process_max_fds",
                                                  "Maximum number of open file descriptors.")
-                .namespace(namespace.as_str()))
+                .namespace(namespace.clone()))
             .unwrap();
         descs.extend(max_fds.desc().into_iter().cloned());
 
         let vsize = Gauge::with_opts(Opts::new("process_virtual_memory_bytes",
                                                "Virtual memory size in bytes.")
-                .namespace(namespace.as_str()))
+                .namespace(namespace.clone()))
             .unwrap();
         descs.extend(vsize.desc().into_iter().cloned());
 
         let rss = Gauge::with_opts(Opts::new("process_resident_memory_bytes",
                                              "Resident memory size in bytes.")
-                .namespace(namespace.as_str()))
+                .namespace(namespace.clone()))
             .unwrap();
         descs.extend(rss.desc().into_iter().cloned());
 
         let start_time = Gauge::with_opts(Opts::new("process_start_time_seconds",
                                                     "Start time of the process since unix epoch \
                                                      in seconds.")
-                .namespace(namespace.as_str()))
+                .namespace(namespace.clone()))
             .unwrap();
         descs.extend(start_time.desc().into_iter().cloned());
 

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -184,15 +184,20 @@ fn open_fds(pid: pid_t) -> Result<usize> {
 //
 // then it returns `Ok(1477460662.0)`
 fn find_statistic(all: &str, pat: &str) -> Result<f64> {
-    all.lines()
+    let literal = all.lines()
         .find(|line| line.contains(pat))
         .and_then(|line| {
             (&line[pat.len()..line.len()])
                 .split(char::is_whitespace)
                 .find(|s| !s.is_empty())
-        })
-        .and_then(|literal| literal.parse().ok())
-        .ok_or(Error::Msg(format!("read statistic {} failed", pat)))
+        });
+    match literal {
+        Some(literal) => {
+            literal.parse().map_err(|e| Error::Msg(format!("read statistic {} failed: {}", pat, e)))
+        }
+        None => Err(Error::Msg(format!("read statistic {} failed", pat))),
+    }
+
 }
 
 const MAX_FD_PATTERN: &'static str = "Max open files";

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -240,9 +240,7 @@ lazy_static! {
         let reg = Registry::default();
 
         // Register a default process collector.
-        if cfg!(feature = "process") {
-            register_default_process_collector(&reg).unwrap();
-        }
+        register_default_process_collector(&reg).unwrap();
 
         reg
     };

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -224,7 +224,7 @@ cfg_if! {
         fn register_default_process_collector(reg: &Registry) -> Result<()> {
             use process_collector::ProcessCollector;
 
-            let pc = ProcessCollector::default();
+            let pc = ProcessCollector::for_self();
             reg.register(Box::new(pc))
         }
     } else {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -220,7 +220,7 @@ impl Registry {
 }
 
 cfg_if! {
-    if #[cfg(feature = "process")] {
+    if #[cfg(all(feature = "process", target_os="linux"))] {
         fn register_default_process_collector(reg: &Registry) -> Result<()> {
             use process_collector::ProcessCollector;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -219,22 +219,18 @@ impl Registry {
     }
 }
 
-// This module is only for conditional compilation.
-mod bridge {
-    use errors::Result;
-    use super::Registry;
+cfg_if! {
+    if #[cfg(feature = "process")] {
+        fn register_default_process_collector(reg: &Registry) -> Result<()> {
+            use process_collector::ProcessCollector;
 
-    #[cfg(feature = "process")]
-    pub fn register_default_process_collector(reg: &Registry) -> Result<()> {
-        use process_collector::ProcessCollector;
-
-        let pc = ProcessCollector::default();
-        reg.register(Box::new(pc))
-    }
-
-    #[cfg(not(feature = "process"))]
-    pub fn register_default_process_collector(_: &Registry) -> Result<()> {
-        Ok(())
+            let pc = ProcessCollector::default();
+            reg.register(Box::new(pc))
+        }
+    } else {
+        fn register_default_process_collector(_: &Registry) -> Result<()> {
+            Ok(())
+        }
     }
 }
 
@@ -244,7 +240,9 @@ lazy_static! {
         let reg = Registry::default();
 
         // Register a default process collector.
-        bridge::register_default_process_collector(&reg).unwrap();
+        if cfg!(feature = "process") {
+            register_default_process_collector(&reg).unwrap();
+        }
 
         reg
     };


### PR DESCRIPTION
Process collector which exports the current state of process metrics including cpu, memory and file descriptor usage as well as the process start time for the given process id.

For now, process collector only supports **Linux** platform.

PTAL @siddontang @disksing @BusyJay 

Close #65 