### PR TITLE
*: add feature "push"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ os:
   - osx
 
 script:
-  - export CARGOOPTS=--features="$FEATURES"
   # Script to test 32-bit versions.
+  - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
+  # Tests again with features enabled.
+  - export CARGOOPTS=--features="$FEATURES"
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ addons:
 env:
   global:
     - RUSTFLAGS=--deny=warnings
+    - FEATURES=push
   matrix:
     - ARCH=x86_64
     - ARCH=i686
@@ -24,6 +25,7 @@ os:
   - osx
 
 script:
+  - export CARGOOPTS=--features="$FEATURES"
   # Script to test 32-bit versions.
   - curl -sSL https://raw.githubusercontent.com/carllerche/travis-rust-matrix/master/test | bash
 
@@ -32,7 +34,9 @@ matrix:
   include:
   - rust: nightly
     script:
-      - cargo test --features="dev nightly"
+      - export FEATURES="$FEATURES nightly dev"
+      - cargo test --features="$FEATURES"
   - rust: nightly
     script:
-      - cargo test --features="dev"
+      - export FEATURES="$FEATURES dev"
+      - cargo test --features="$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.2.7"
+version = "0.2.8"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ include = [
 default = []
 dev = ["clippy"]
 nightly = []
+push = ["hyper", "libc"]
 
 [[bench]]
 name = "benches"
@@ -27,7 +28,7 @@ quick-error = "0.2"
 clippy = {version = "^0", optional = true}
 fnv = "1.0.3"
 lazy_static = "0.2.1"
-libc = "0.2"
+libc = {version = "0.2", optional = true}
 regex = "0.1"
 
 [dependencies.hyper]
@@ -35,6 +36,8 @@ version = "0.9"
 # disable hyper ssl
 #  refer to https://github.com/hyperium/hyper/issues/903#issuecomment-242798266
 default-features = false
+optional = true
 
 [dev-dependencies]
 getopts = "0.2.14"
+hyper = {version = "0.9", default-features = false}

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,10 @@ build:
 	cargo build --features default
 
 test:
-	cargo test --features default -- --nocapture 
+	cargo test --features="push" -- --nocapture
 
 dev: format
-	cargo build --features dev
-	cargo test --features="nightly dev" -- --nocapture
+	cargo test --features="push nightly dev" -- --nocapture
 
 bench: format
 	cargo bench --features dev -- --nocapture
@@ -24,5 +23,6 @@ clean:
 examples:
 	cargo build --example example_embed
 	cargo build --example example_hyper
+	cargo build --features="push" --example example_push
 
 .PHONY: all examples

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -11,84 +11,75 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![cfg_attr(not(feature = "push"), allow(unused_imports, dead_code))]
+
 #[macro_use]
 extern crate prometheus;
 #[macro_use]
 extern crate lazy_static;
 extern crate getopts;
 
-mod bridge {
-    #[cfg(feature="push")]
-    mod push {
-        use std::env;
-        use std::time;
-        use std::thread;
+use std::env;
+use std::time;
+use std::thread;
 
-        use getopts::Options;
-        use prometheus::{self, Histogram, Counter};
+use getopts::Options;
+use prometheus::{Histogram, Counter};
 
-        lazy_static! {
-            static ref PUSH_COUNTER: Counter = register_counter!(
-                opts!(
-                    "example_push_total",
-                    "Total number of prometheus client pushed."
-                )
-            ).unwrap();
+lazy_static! {
+    static ref PUSH_COUNTER: Counter = register_counter!(
+        opts!(
+            "example_push_total",
+            "Total number of prometheus client pushed."
+        )
+    ).unwrap();
 
-            static ref PUSH_REQ_HISTOGRAM: Histogram = register_histogram!(
-                histogram_opts!(
-                    "example_push_request_duration_seconds",
-                    "The push request latencies in seconds."
-                )
-            ).unwrap();
-        }
-
-        pub fn demo() {
-            let args: Vec<String> = env::args().collect();
-            let program = args[0].clone();
-
-            let mut opts = Options::new();
-            opts.optopt("A",
-                        "addr",
-                        "prometheus pushgateway address",
-                        "default is 127.0.0.1:9091");
-            opts.optflag("h", "help", "print this help menu");
-
-            let matches = opts.parse(&args).unwrap();
-            if matches.opt_present("h") || !matches.opt_present("A") {
-                let brief = format!("Usage: {} [options]", program);
-                print!("{}", opts.usage(&brief));
-                return;
-            }
-            println!("Pushing, please start Pushgateway first.");
-
-            let address = matches.opt_str("A").unwrap_or("127.0.0.1:9091".to_owned());
-            for _ in 0..5 {
-                thread::sleep(time::Duration::from_secs(2));
-                PUSH_COUNTER.inc();
-                let metric_familys = prometheus::gather();
-                let _timer = PUSH_REQ_HISTOGRAM.start_timer(); // drop as observe
-                prometheus::push::push_metrics("example_push",
-                                         labels!{"instance".to_owned() => "HAL-9000".to_owned(),},
-                                         &address,
-                                         metric_familys)
-                    .unwrap();
-            }
-
-            println!("Okay, please check the Pushgateway.");
-        }
-    }
-
-    #[cfg(feature="push")]
-    pub use self::push::demo;
-
-    #[cfg(not(feature="push"))]
-    pub fn demo() {
-        println!("Please enable feature \"push\", try:\n\tcargo run \
-                  --features=\"push\" --example example_push");
-    }
+    static ref PUSH_REQ_HISTOGRAM: Histogram = register_histogram!(
+        histogram_opts!(
+            "example_push_request_duration_seconds",
+            "The push request latencies in seconds."
+        )
+    ).unwrap();
 }
 
+#[cfg(feature="push")]
 fn main() {
-    bridge::demo()
+    let args: Vec<String> = env::args().collect();
+    let program = args[0].clone();
+
+    let mut opts = Options::new();
+    opts.optopt("A",
+                "addr",
+                "prometheus pushgateway address",
+                "default is 127.0.0.1:9091");
+    opts.optflag("h", "help", "print this help menu");
+
+    let matches = opts.parse(&args).unwrap();
+    if matches.opt_present("h") || !matches.opt_present("A") {
+        let brief = format!("Usage: {} [options]", program);
+        print!("{}", opts.usage(&brief));
+        return;
+    }
+    println!("Pushing, please start Pushgateway first.");
+
+    let address = matches.opt_str("A").unwrap_or("127.0.0.1:9091".to_owned());
+    for _ in 0..5 {
+        thread::sleep(time::Duration::from_secs(2));
+        PUSH_COUNTER.inc();
+        let metric_familys = prometheus::gather();
+        let _timer = PUSH_REQ_HISTOGRAM.start_timer(); // drop as observe
+        prometheus::push_metrics("example_push",
+                                 labels!{"instance".to_owned() => "HAL-9000".to_owned(),},
+                                 &address,
+                                 metric_familys)
+            .unwrap();
+    }
+
+    println!("Okay, please check the Pushgateway.");
+}
+
+#[cfg(not(feature="push"))]
+fn main() {
+    println!(r#"Please enable feature "push", try:
+    cargo run --features="push" --example example_push"#);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ extern crate protobuf;
 extern crate fnv;
 #[macro_use]
 extern crate lazy_static;
+#[cfg(feature="push")]
 extern crate hyper;
+#[cfg(feature="push")]
 extern crate libc;
 extern crate regex;
 
@@ -41,13 +43,14 @@ mod registry;
 #[allow(dead_code)]
 mod vec;
 mod histogram;
-mod push;
 mod atomic64;
 
 // Mods
 
 /// Protocol buffers format of metrics.
 pub mod proto;
+#[cfg(feature="push")]
+pub mod push;
 
 // Traits
 pub use self::encoder::Encoder;
@@ -66,8 +69,6 @@ pub use self::histogram::{Histogram, HistogramVec, HistogramOpts, HistogramTimer
 // Functions
 pub use self::registry::{gather, register, unregister};
 pub use self::histogram::{linear_buckets, exponential_buckets};
-pub use self::push::{push_metrics, push_add_metrics, push_collector, push_add_collector,
-                     hostname_grouping_key};
 
 // Constants
 pub use self::encoder::TEXT_FORMAT;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,14 @@ mod registry;
 #[allow(dead_code)]
 mod vec;
 mod histogram;
+#[cfg(feature="push")]
+mod push;
 mod atomic64;
 
 // Mods
 
 /// Protocol buffers format of metrics.
 pub mod proto;
-#[cfg(feature="push")]
-pub mod push;
 
 // Traits
 pub use self::encoder::Encoder;
@@ -69,6 +69,9 @@ pub use self::histogram::{Histogram, HistogramVec, HistogramOpts, HistogramTimer
 // Functions
 pub use self::registry::{gather, register, unregister};
 pub use self::histogram::{linear_buckets, exponential_buckets};
+#[cfg(feature="push")]
+pub use self::push::{push_metrics, push_add_metrics, push_collector, push_add_collector,
+                     hostname_grouping_key};
 
 // Constants
 pub use self::encoder::TEXT_FORMAT;


### PR DESCRIPTION
This PR introduces a new feature `push`.  It allows building core instrumentation library without hyper and libc.

~~There are a few API changes:~~
  - ~~mod `push` is published.~~
  - ~~following functions are moved to mod `push`.~~
    ```
    push_metrics
    push_add_metrics
    push_collector
    push_add_collector
    hostname_grouping_key
    ```

Close #84 

PTAL @siddontang @kamalmarhubi 