### PR TITLE
*: Use &str instead of Into<String>

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -30,7 +30,7 @@ pub struct Counter {
 
 impl Counter {
     /// `new` creates a `Counter` with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Counter> {
+    pub fn new(name: &str, help: &str) -> Result<Counter> {
         let opts = Opts::new(name, help);
         Counter::with_opts(opts)
     }

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -30,7 +30,7 @@ pub struct Gauge {
 
 impl Gauge {
     /// `new` create a `Guage` with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Gauge> {
+    pub fn new(name: &str, help: &str) -> Result<Gauge> {
         let opts = Opts::new(name, help);
         Gauge::with_opts(opts)
     }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -86,7 +86,7 @@ pub struct HistogramOpts {
 
 impl HistogramOpts {
     /// `new` creates a `HistogramOpts` with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> HistogramOpts {
+    pub fn new(name: &str, help: &str) -> HistogramOpts {
         HistogramOpts {
             common_opts: Opts::new(name, help),
             buckets: Vec::from(DEFAULT_BUCKETS as &'static [f64]),
@@ -94,14 +94,14 @@ impl HistogramOpts {
     }
 
     /// `namespace` sets the namespace.
-    pub fn namespace<S: Into<String>>(mut self, namesapce: S) -> Self {
-        self.common_opts.namespace = namesapce.into();
+    pub fn namespace(mut self, namespace: &str) -> Self {
+        self.common_opts.namespace = namespace.to_string();
         self
     }
 
     /// `subsystem` sets the sub system.
-    pub fn subsystem<S: Into<String>>(mut self, subsystem: S) -> Self {
-        self.common_opts.subsystem = subsystem.into();
+    pub fn subsystem(mut self, subsystem: &str) -> Self {
+        self.common_opts.subsystem = subsystem.to_string();
         self
     }
 
@@ -112,7 +112,7 @@ impl HistogramOpts {
     }
 
     /// `const_label` adds a const label.
-    pub fn const_label<S: Into<String>>(mut self, name: S, value: S) -> Self {
+    pub fn const_label(mut self, name: &str, value: &str) -> Self {
         self.common_opts = self.common_opts.const_label(name, value);
         self
     }
@@ -124,7 +124,7 @@ impl HistogramOpts {
     }
 
     /// `variable_label` adds a variable label.
-    pub fn variable_label<S: Into<String>>(mut self, name: S) -> Self {
+    pub fn variable_label(mut self, name: &str) -> Self {
         self.common_opts = self.common_opts.variable_label(name);
         self
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -87,26 +87,26 @@ pub struct Opts {
 
 impl Opts {
     /// `new` creates the Opts with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Opts {
+    pub fn new(name: &str, help: &str) -> Opts {
         Opts {
-            namespace: "".to_owned(),
-            subsystem: "".to_owned(),
-            name: name.into(),
-            help: help.into(),
+            namespace: String::new(),
+            subsystem: String::new(),
+            name: name.to_string(),
+            help: help.to_string(),
             const_labels: HashMap::new(),
             variable_labels: Vec::new(),
         }
     }
 
     /// `namespace` sets the namespace.
-    pub fn namespace<S: Into<String>>(mut self, namesapce: S) -> Self {
-        self.namespace = namesapce.into();
+    pub fn namespace(mut self, namesapce: &str) -> Self {
+        self.namespace = namesapce.to_string();
         self
     }
 
     /// `subsystem` sets the sub system.
-    pub fn subsystem<S: Into<String>>(mut self, subsystem: S) -> Self {
-        self.subsystem = subsystem.into();
+    pub fn subsystem(mut self, subsystem: &str) -> Self {
+        self.subsystem = subsystem.to_string();
         self
     }
 
@@ -117,8 +117,8 @@ impl Opts {
     }
 
     /// `const_label` adds a const label.
-    pub fn const_label<S: Into<String>>(mut self, name: S, value: S) -> Self {
-        self.const_labels.insert(name.into(), value.into());
+    pub fn const_label(mut self, name: &str, value: &str) -> Self {
+        self.const_labels.insert(name.to_string(), value.to_string());
         self
     }
 
@@ -129,8 +129,8 @@ impl Opts {
     }
 
     /// `variable_label` adds a variable label.
-    pub fn variable_label<S: Into<String>>(mut self, name: S) -> Self {
-        self.variable_labels.push(name.into());
+    pub fn variable_label(mut self, name: &str) -> Self {
+        self.variable_labels.push(name.to_string());
         self
     }
 


### PR DESCRIPTION
This prevents accidental allocations and copies within the library by
forcing the conversion to `String` to happen as late as possible. With
`Into<String>` parameters, arguments could be converted multiple times.

The only two types in libstd that can be passed as `Into<String>` are
`String` and `&str`. Accepting `&str` achieves the same, with the minor
change that a `String` must be passed by reference:

    let name: String = "my_metric".to_string();
    let help: String = "some help string".to_string();
    let opts = Opts::new(&name, &help);

In most uses of Prometheus, the strings will be `&'static str` anyway,
so this should not have much of an effect.