### PR TITLE
desc: Replace regex name validation with functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ clippy = {version = "^0", optional = true}
 fnv = "1.0.3"
 lazy_static = "0.2.1"
 libc = "0.2"
-regex = "0.1"
 
 [dependencies.hyper]
 version = "0.9"

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -217,7 +217,7 @@ mod tests {
             ("a-",         false),
         ];
 
-        for &(name, expected) in tbl.iter() {
+        for &(name, expected) in &tbl {
             assert_eq!(is_valid_metric_name(name), expected);
         }
     }
@@ -240,7 +240,7 @@ mod tests {
             ("a_b_9_d:x_", false),
         ];
 
-        for &(name, expected) in tbl.iter() {
+        for &(name, expected) in &tbl {
             assert_eq!(is_valid_label_name(name), expected);
         }
     }

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -202,37 +202,47 @@ mod tests {
 
     #[test]
     fn test_is_valid_metric_name() {
-        assert_eq!(is_valid_metric_name(":"),          true);
-        assert_eq!(is_valid_metric_name("_"),          true);
-        assert_eq!(is_valid_metric_name("a"),          true);
-        assert_eq!(is_valid_metric_name(":9"),         true);
-        assert_eq!(is_valid_metric_name("_9"),         true);
-        assert_eq!(is_valid_metric_name("a9"),         true);
-        assert_eq!(is_valid_metric_name("a_b_9_d:x_"), true);
+        let tbl = [
+            (":",          true ),
+            ("_",          true ),
+            ("a",          true ),
+            (":9",         true ),
+            ("_9",         true ),
+            ("a9",         true ),
+            ("a_b_9_d:x_", true ),
+            ("9",          false),
+            ("9:",         false),
+            ("9_",         false),
+            ("9a",         false),
+            ("a-",         false),
+        ];
 
-        assert_eq!(is_valid_metric_name("9"),          false);
-        assert_eq!(is_valid_metric_name("9:"),         false);
-        assert_eq!(is_valid_metric_name("9_"),         false);
-        assert_eq!(is_valid_metric_name("9a"),         false);
-        assert_eq!(is_valid_metric_name("a-"),         false);
+        for &(name, expected) in tbl.iter() {
+            assert_eq!(is_valid_metric_name(name), expected);
+        }
     }
 
     #[test]
     fn test_is_valid_label_name() {
-        assert_eq!(is_valid_label_name("_"),          true);
-        assert_eq!(is_valid_label_name("a"),          true);
-        assert_eq!(is_valid_label_name("_9"),         true);
-        assert_eq!(is_valid_label_name("a9"),         true);
-        assert_eq!(is_valid_label_name("a_b_9_dx_"),  true);
+        let tbl = [
+            ("_",          true ),
+            ("a",          true ),
+            ("_9",         true ),
+            ("a9",         true ),
+            ("a_b_9_dx_",  true ),
+            (":",          false),
+            (":9",         false),
+            ("9",          false),
+            ("9:",         false),
+            ("9_",         false),
+            ("9a",         false),
+            ("a-",         false),
+            ("a_b_9_d:x_", false),
+        ];
 
-        assert_eq!(is_valid_label_name(":"),          false);
-        assert_eq!(is_valid_label_name(":9"),         false);
-        assert_eq!(is_valid_label_name("9"),          false);
-        assert_eq!(is_valid_label_name("9:"),         false);
-        assert_eq!(is_valid_label_name("9_"),         false);
-        assert_eq!(is_valid_label_name("9a"),         false);
-        assert_eq!(is_valid_label_name("a-"),         false);
-        assert_eq!(is_valid_label_name("a_b_9_d:x_"), false);
+        for &(name, expected) in tbl.iter() {
+            assert_eq!(is_valid_label_name(name), expected);
+        }
     }
 
     #[test]

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -197,8 +197,43 @@ pub trait Describer {
 mod tests {
     use std::collections::HashMap;
 
-    use desc::Desc;
+    use desc::{Desc, is_valid_metric_name, is_valid_label_name};
     use errors::Error;
+
+    #[test]
+    fn test_is_valid_metric_name() {
+        assert_eq!(is_valid_metric_name(":"),          true);
+        assert_eq!(is_valid_metric_name("_"),          true);
+        assert_eq!(is_valid_metric_name("a"),          true);
+        assert_eq!(is_valid_metric_name(":9"),         true);
+        assert_eq!(is_valid_metric_name("_9"),         true);
+        assert_eq!(is_valid_metric_name("a9"),         true);
+        assert_eq!(is_valid_metric_name("a_b_9_d:x_"), true);
+
+        assert_eq!(is_valid_metric_name("9"),          false);
+        assert_eq!(is_valid_metric_name("9:"),         false);
+        assert_eq!(is_valid_metric_name("9_"),         false);
+        assert_eq!(is_valid_metric_name("9a"),         false);
+        assert_eq!(is_valid_metric_name("a-"),         false);
+    }
+
+    #[test]
+    fn test_is_valid_label_name() {
+        assert_eq!(is_valid_label_name("_"),          true);
+        assert_eq!(is_valid_label_name("a"),          true);
+        assert_eq!(is_valid_label_name("_9"),         true);
+        assert_eq!(is_valid_label_name("a9"),         true);
+        assert_eq!(is_valid_label_name("a_b_9_dx_"),  true);
+
+        assert_eq!(is_valid_label_name(":"),          false);
+        assert_eq!(is_valid_label_name(":9"),         false);
+        assert_eq!(is_valid_label_name("9"),          false);
+        assert_eq!(is_valid_label_name("9:"),         false);
+        assert_eq!(is_valid_label_name("9_"),         false);
+        assert_eq!(is_valid_label_name("9a"),         false);
+        assert_eq!(is_valid_label_name("a-"),         false);
+        assert_eq!(is_valid_label_name("a_b_9_d:x_"), false);
+    }
 
     #[test]
     fn test_invalid_const_label_name() {

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -12,19 +12,54 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ascii::AsciiExt;
 use std::collections::{HashMap, BTreeSet};
 use std::hash::Hasher;
 
 use fnv::FnvHasher;
-use regex::Regex;
 
 use proto::LabelPair;
 use errors::{Result, Error};
 use metrics::SEPARATOR_BYTE;
 
-lazy_static! {
-    static ref VALID_METRIC_NAME: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_:]*$").unwrap();
-    static ref VALID_LABEL_NAME: Regex = Regex::new(r"^[a-zA-Z_][a-zA-Z0-9_]*$").unwrap();
+// Details of required format are at
+//   https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels
+fn is_valid_metric_name(name: &str) -> bool {
+    // Valid metric names must match regex [a-zA-Z_:][a-zA-Z0-9_:]*.
+    fn valid_start(c: char) -> bool {
+        c.is_ascii() && match c as u8 {
+            b'a'...b'z' | b'A'...b'Z' | b'_' | b':' => true,
+            _ => false,
+        }
+    }
+
+    fn valid_char(c: char) -> bool {
+        c.is_ascii() && match c as u8 {
+            b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'_' | b':' => true,
+            _ => false
+        }
+    }
+
+    name.starts_with(valid_start) && !name.contains(|c| !valid_char(c))
+}
+
+fn is_valid_label_name(name: &str) -> bool {
+    // Valid label names must match regex [a-zA-Z_][a-zA-Z0-9_]*.
+    fn valid_start(c: char) -> bool {
+        c.is_ascii() && match c as u8 {
+            b'a'...b'z' | b'A'...b'Z' | b'_' => true,
+            _ => false,
+        }
+    }
+
+    fn valid_char(c: char) -> bool {
+        c.is_ascii() && match c as u8 {
+            b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'_' => true,
+            _ => false
+        }
+    }
+
+    name.starts_with(valid_start) && !name.contains(|c| !valid_char(c))
 }
 
 /// Desc is the descriptor used by every Prometheus Metric. It is essentially
@@ -83,7 +118,7 @@ impl Desc {
             return Err(Error::Msg("empty help string".into()));
         }
 
-        if !VALID_METRIC_NAME.is_match(&desc.fq_name) {
+        if !is_valid_metric_name(&desc.fq_name) {
             return Err(Error::Msg(format!("'{}' is not a valid metric name", desc.fq_name)));
         }
 
@@ -93,7 +128,7 @@ impl Desc {
         let mut label_names = BTreeSet::new();
 
         for label_name in const_labels.keys() {
-            if !VALID_LABEL_NAME.is_match(label_name) {
+            if !is_valid_label_name(label_name) {
                 return Err(Error::Msg(format!("'{}' is not a valid label name", &label_name)));
             }
 
@@ -111,7 +146,7 @@ impl Desc {
         // cannot be in a regular label name. That prevents matching the label
         // dimension with a different mix between preset and variable labels.
         for label_name in &desc.variable_labels {
-            if !VALID_LABEL_NAME.is_match(label_name) {
+            if !is_valid_label_name(label_name) {
                 return Err(Error::Msg(format!("'{}' is not a valid label name", &label_name)));
             }
 
@@ -198,7 +233,7 @@ mod tests {
 
     #[test]
     fn test_invalid_metric_name() {
-        for &name in &["-dash", "9gag", ":colon", "has space"] {
+        for &name in &["-dash", "9gag", "has space"] {
             let res = Desc::new(name.into(), "help".into(), vec![], HashMap::new())
                 .err()
                 .expect(format!("expected error for {}", name).as_ref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,6 @@ extern crate fnv;
 extern crate lazy_static;
 extern crate hyper;
 extern crate libc;
-extern crate regex;
 
 mod errors;
 mod encoder;


### PR DESCRIPTION
This allows dropping the dependency on regex, making the instrumentation
library much more lightweight.

This also fixes a bug with metric name validation, where an initial
colon was incorrectly disallowed. See data model for correct format:
  https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

This may be because the library closely follows the official Go library,
which also had this issue.

Refs #85
Refs https://github.com/prometheus/client_golang/pull/255