### PR TITLE
macros: refactor histogram macros

### DIFF
--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -21,7 +21,7 @@ use hyper::header::ContentType;
 use hyper::server::{Server, Request, Response};
 use hyper::mime::Mime;
 
-use prometheus::{Counter, Gauge, Histogram, Encoder, TextEncoder};
+use prometheus::{Counter, Gauge, HistogramVec, Encoder, TextEncoder};
 
 lazy_static! {
     static ref HTTP_COUNTER: Counter = register_counter!(
@@ -38,12 +38,12 @@ lazy_static! {
         labels!{"handler" => "all",}
     ).unwrap();
 
-    static ref HTTP_REQ_HISTOGRAM: Histogram = register_histogram!(
+    static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
         histogram_opts!(
             "example_http_request_duration_seconds",
-            "The HTTP request latencies in seconds.",
-            labels!{"handler" => "all",}
-        )
+            "The HTTP request latencies in seconds."
+        ),
+        &["handler"]
     ).unwrap();
 }
 
@@ -55,7 +55,7 @@ fn main() {
         .unwrap()
         .handle(move |_: Request, mut res: Response| {
             HTTP_COUNTER.inc();
-            let timer = HTTP_REQ_HISTOGRAM.start_timer();
+            let timer = HTTP_REQ_HISTOGRAM.with_label_values(&["all"]).start_timer();
 
             let metric_familys = prometheus::gather();
             let mut buffer = vec![];


### PR DESCRIPTION
Macro API changes:

* `histogram_opts!`
  * Remove: 
    - `histogram_opts!( $ NAME : expr , $ HELP : expr , [ $ ( $ BUCKETS : expr ) , * ] )`
    - `histogram_opts!( $ NAME : expr , $ HELP : expr $ ( , $ CONST_LABELS : expr ) * )`
    - `histogram_opts!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , [ $ ( $ BUCKETS : expr ) , + ] )`
  * Add:
    - `histogram_opts!( $ NAME : expr , $ HELP : expr )`
    - `histogram_opts!( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr )`

* `register_histogram!`
  * Remove: 
    - `register_histogram!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr )`
    - `register_histogram!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , [ $ ( $ BUCKETS : expr ) , + ] )`
  * Add:
    - `register_histogram!( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr )`


* `register_histogram_vec!`
  * Remove: 
    - `register_histogram_vec!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , $ LABELS_NAMES : expr )`
  * Add:
    - `register_histogram_vec!( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr , $ BUCKETS : expr)`


In a nutshell, `CONST_LABELS` are replaced with `BUCKETS`. 

Close #55 

PTAL @siddontang 