### PR TITLE
Refactor macros

### DIFF
--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -33,9 +33,11 @@ lazy_static! {
     ).unwrap();
 
     static ref HTTP_BODY_GAUGE: Gauge = register_gauge!(
-        "example_http_response_size_bytes",
-        "The HTTP response sizes in bytes.",
-        labels!{"handler" => "all",}
+        opts!(
+            "example_http_response_size_bytes",
+            "The HTTP response sizes in bytes.",
+            labels!{"handler" => "all",}
+        )
     ).unwrap();
 
     static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -21,7 +21,7 @@ use hyper::header::ContentType;
 use hyper::server::{Server, Request, Response};
 use hyper::mime::Mime;
 
-use prometheus::{Counter, Gauge, Histogram, Encoder, TextEncoder};
+use prometheus::{Counter, Gauge, HistogramVec, Encoder, TextEncoder};
 
 lazy_static! {
     static ref HTTP_COUNTER: Counter = register_counter!(
@@ -38,12 +38,12 @@ lazy_static! {
         labels!{"handler" => "all",}
     ).unwrap();
 
-    static ref HTTP_REQ_HISTOGRAM: Histogram = register_histogram!(
+    static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
         histogram_opts!(
             "example_http_request_duration_seconds",
-            "The HTTP request latencies in seconds.",
-            labels!{"handler" => "all",}
-        )
+            "The HTTP request latencies in seconds."
+        ),
+        &["handler"]
     ).unwrap();
 }
 
@@ -55,7 +55,7 @@ fn main() {
         .unwrap()
         .handle(move |_: Request, mut res: Response| {
             HTTP_COUNTER.inc();
-            let timer = HTTP_REQ_HISTOGRAM.start_timer();
+            let timer = HTTP_REQ_HISTOGRAM.with_label_values(&["all"]).start_timer();
 
             let metric_familys = prometheus::gather();
             let mut buffer = vec![];

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -41,10 +41,8 @@ lazy_static! {
     ).unwrap();
 
     static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
-        histogram_opts!(
-            "example_http_request_duration_seconds",
-            "The HTTP request latencies in seconds."
-        ),
+        "example_http_request_duration_seconds",
+        "The HTTP request latencies in seconds.",
         &["handler"]
     ).unwrap();
 }

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -28,10 +28,8 @@ use prometheus::{Histogram, Counter};
 
 lazy_static! {
     static ref PUSH_COUNTER: Counter = register_counter!(
-        opts!(
-            "example_push_total",
-            "Total number of prometheus client pushed."
-        )
+        "example_push_total",
+        "Total number of prometheus client pushed."
     ).unwrap();
 
     static ref PUSH_REQ_HISTOGRAM: Histogram = register_histogram!(

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -35,10 +35,8 @@ lazy_static! {
     ).unwrap();
 
     static ref PUSH_REQ_HISTOGRAM: Histogram = register_histogram!(
-        histogram_opts!(
-            "example_push_request_duration_seconds",
-            "The push request latencies in seconds."
-        )
+        "example_push_request_duration_seconds",
+        "The push request latencies in seconds."
     ).unwrap();
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -148,24 +148,18 @@ macro_rules! histogram_opts {
 /// ```
 /// # #[macro_use] extern crate prometheus;
 /// # fn main() {
-/// let opts = opts!("test_macro_counter_1",
-///                     "help",
-///                     labels!{"test" => "hello", "foo" => "bar",});
-///
+/// let opts = opts!("test_macro_counter_1", "help");
 /// let res1 = register_counter!(opts);
 /// assert!(res1.is_ok());
 ///
 /// let res2 = register_counter!("test_macro_counter_2", "help");
 /// assert!(res2.is_ok());
-///
-/// let res3 = register_counter!("test_macro_counter_3", "help", labels!{ "a" => "b",});
-/// assert!(res3.is_ok());
 /// # }
 /// ```
 #[macro_export]
 macro_rules! register_counter {
-    ( $ NAME : expr , $ HELP : expr $ ( , $ CONST_LABELS : expr ) * ) => {
-        register_counter!(opts!($NAME, $HELP $(, $CONST_LABELS)*))
+    ( $ NAME : expr , $ HELP : expr ) => {
+        register_counter!(opts!($NAME, $HELP))
     };
 
     ( $ OPTS : expr ) => {
@@ -183,20 +177,11 @@ macro_rules! register_counter {
 /// ```
 /// # #[macro_use] extern crate prometheus;
 /// # fn main() {
-/// let opts = opts!("test_macro_counter_vec_1",
-///                   "help",
-///                   labels!{"test" => "hello", "foo" => "bar",});
-///
+/// let opts = opts!("test_macro_counter_vec_1", "help");
 /// let counter_vec = register_counter_vec!(opts, &["a", "b"]);
 /// assert!(counter_vec.is_ok());
 ///
 /// let counter_vec = register_counter_vec!("test_macro_counter_vec_2", "help", &["a", "b"]);
-/// assert!(counter_vec.is_ok());
-///
-/// let counter_vec = register_counter_vec!("test_macro_counter_vec_3",
-///                                         "help",
-///                                         labels!{"test" => "hello", "foo" => "bar",},
-///                                         &["a", "b"]);
 /// assert!(counter_vec.is_ok());
 /// # }
 /// ```
@@ -214,12 +199,6 @@ macro_rules! register_counter_vec {
             register_counter_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
         }
     };
-
-    ( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            register_counter_vec!(opts!($NAME, $HELP, $CONST_LABELS), $LABELS_NAMES)
-        }
-    };
 }
 
 /// Create a Gauge and register to default registry.
@@ -229,24 +208,18 @@ macro_rules! register_counter_vec {
 /// ```
 /// # #[macro_use] extern crate prometheus;
 /// # fn main() {
-/// let opts = opts!("test_macro_gauge",
-///                     "help",
-///                     labels!{"test" => "hello", "foo" => "bar",});
-///
+/// let opts = opts!("test_macro_gauge", "help");
 /// let res1 = register_gauge!(opts);
 /// assert!(res1.is_ok());
 ///
 /// let res2 = register_gauge!("test_macro_gauge_2", "help");
 /// assert!(res2.is_ok());
-///
-/// let res3 = register_gauge!("test_macro_gauge_3", "help", labels!{"a" => "b",});
-/// assert!(res3.is_ok());
 /// # }
 /// ```
 #[macro_export]
 macro_rules! register_gauge {
-    ( $ NAME : expr , $ HELP : expr $ ( , $ CONST_LABELS : expr ) * ) => {
-        register_gauge!(opts!($NAME, $HELP $(, $CONST_LABELS)*))
+    ( $ NAME : expr , $ HELP : expr ) => {
+        register_gauge!(opts!($NAME, $HELP))
     };
 
     ( $ OPTS : expr ) => {
@@ -264,20 +237,11 @@ macro_rules! register_gauge {
 /// ```
 /// # #[macro_use] extern crate prometheus;
 /// # fn main() {
-/// let opts = opts!("test_macro_gauge_vec_1",
-///                  "help",
-///                  labels!{"test" => "hello", "foo" => "bar",});
-///
+/// let opts = opts!("test_macro_gauge_vec_1", "help");
 /// let gauge_vec = register_gauge_vec!(opts, &["a", "b"]);
 /// assert!(gauge_vec.is_ok());
 ///
 /// let gauge_vec = register_gauge_vec!("test_macro_gauge_vec_2", "help", &["a", "b"]);
-/// assert!(gauge_vec.is_ok());
-///
-/// let gauge_vec = register_gauge_vec!("test_macro_gauge_vec_3",
-///                                     "help",
-///                                     labels!{"test" => "hello", "foo" => "bar",},
-///                                     &["a", "b"]);
 /// assert!(gauge_vec.is_ok());
 /// # }
 /// ```
@@ -293,12 +257,6 @@ macro_rules! register_gauge_vec {
     ( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr ) => {
         {
             register_gauge_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
-        }
-    };
-
-    ( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            register_gauge_vec!(opts!($NAME, $HELP, $CONST_LABELS), $LABELS_NAMES)
         }
     };
 }


### PR DESCRIPTION
Macro API changes:

* `register_(counter|gauge)`
  * Reomved:
    - `( $ NAME : expr , $ HELP : expr $ ( , $ CONST_LABELS : expr ) * )`

* `register_(counter_vec|gauge_vec)`
  * Reomved
    - `( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , $ LABELS_NAMES : expr )`

* `histogram_opts!`
  * Remove: 
    - `histogram_opts!( $ NAME : expr , $ HELP : expr , [ $ ( $ BUCKETS : expr ) , * ] )`
    - `histogram_opts!( $ NAME : expr , $ HELP : expr $ ( , $ CONST_LABELS : expr ) * )`
    - `histogram_opts!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , [ $ ( $ BUCKETS : expr ) , + ] )`
  * Add:
    - ~~`histogram_opts!( $ OPTS : expr , $ BUCKETS : expr )`~~
    - `histogram_opts!( $ NAME : expr , $ HELP : expr )`
    - `histogram_opts!( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr )`
    - `histogram_opts!( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr , $ CONST_LABELS : expr )`

* `register_histogram!`
  * Remove: 
    - `register_histogram!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr )`
    - `register_histogram!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , [ $ ( $ BUCKETS : expr ) , + ] )`
  * Add:
    - `register_histogram!( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr )`

* `register_histogram_vec!`
  * Remove: 
    - `register_histogram_vec!( $ NAME : expr , $ HELP : expr , $ CONST_LABELS : expr , $ LABELS_NAMES : expr )`
  * Add:
    - `register_histogram_vec!( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr , $ BUCKETS : expr)`

In a nutshell, `CONST_LABELS` are removed from `register_(counter|counter_vec|gauge|gauge_vec|histogram|histogram_vec)`.

The only way to include `CONST_LABELS` is through `opts!`.

---------

~~Note that `histogram_opts!("name", "help")` is no longer available, it should be replaced with `histogram_opts!(opt!("name", "help"))`.~~

Close #55 and #90

PTAL @siddontang 