### PR TITLE
support local histogram

### DIFF
--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -39,3 +39,23 @@ fn bench_histogram_timer(b: &mut Bencher) {
         .unwrap();
     b.iter(|| histogram.start_timer())
 }
+
+#[bench]
+fn bench_histogram_local(b: &mut Bencher) {
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
+                                                            "A histogram to benchmark it."))
+        .unwrap();
+    let local = histogram.local();
+    b.iter(|| local.observe(3.1415));
+    local.flush();
+}
+
+#[bench]
+fn bench_histogram_local_timer(b: &mut Bencher) {
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
+                                                            "A histogram to benchmark it."))
+        .unwrap();
+    let local = histogram.local();
+    b.iter(|| local.start_timer());
+    local.flush();
+}

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -42,7 +42,7 @@ fn bench_histogram_timer(b: &mut Bencher) {
 
 #[bench]
 fn bench_histogram_local(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_local",
                                                             "A histogram to benchmark it."))
         .unwrap();
     let local = histogram.local();
@@ -52,7 +52,7 @@ fn bench_histogram_local(b: &mut Bencher) {
 
 #[bench]
 fn bench_histogram_local_timer(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_local_timer",
                                                             "A histogram to benchmark it."))
         .unwrap();
     let local = histogram.local();

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -27,16 +27,18 @@ use metrics::SEPARATOR_BYTE;
 fn is_valid_metric_name(name: &str) -> bool {
     // Valid metric names must match regex [a-zA-Z_:][a-zA-Z0-9_:]*.
     fn valid_start(c: char) -> bool {
-        c.is_ascii() && match c as u8 {
+        c.is_ascii() &&
+        match c as u8 {
             b'a'...b'z' | b'A'...b'Z' | b'_' | b':' => true,
             _ => false,
         }
     }
 
     fn valid_char(c: char) -> bool {
-        c.is_ascii() && match c as u8 {
+        c.is_ascii() &&
+        match c as u8 {
             b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'_' | b':' => true,
-            _ => false
+            _ => false,
         }
     }
 
@@ -46,16 +48,18 @@ fn is_valid_metric_name(name: &str) -> bool {
 fn is_valid_label_name(name: &str) -> bool {
     // Valid label names must match regex [a-zA-Z_][a-zA-Z0-9_]*.
     fn valid_start(c: char) -> bool {
-        c.is_ascii() && match c as u8 {
+        c.is_ascii() &&
+        match c as u8 {
             b'a'...b'z' | b'A'...b'Z' | b'_' => true,
             _ => false,
         }
     }
 
     fn valid_char(c: char) -> bool {
-        c.is_ascii() && match c as u8 {
+        c.is_ascii() &&
+        match c as u8 {
             b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'_' => true,
-            _ => false
+            _ => false,
         }
     }
 
@@ -202,20 +206,18 @@ mod tests {
 
     #[test]
     fn test_is_valid_metric_name() {
-        let tbl = [
-            (":",          true ),
-            ("_",          true ),
-            ("a",          true ),
-            (":9",         true ),
-            ("_9",         true ),
-            ("a9",         true ),
-            ("a_b_9_d:x_", true ),
-            ("9",          false),
-            ("9:",         false),
-            ("9_",         false),
-            ("9a",         false),
-            ("a-",         false),
-        ];
+        let tbl = [(":", true),
+                   ("_", true),
+                   ("a", true),
+                   (":9", true),
+                   ("_9", true),
+                   ("a9", true),
+                   ("a_b_9_d:x_", true),
+                   ("9", false),
+                   ("9:", false),
+                   ("9_", false),
+                   ("9a", false),
+                   ("a-", false)];
 
         for &(name, expected) in &tbl {
             assert_eq!(is_valid_metric_name(name), expected);
@@ -224,21 +226,19 @@ mod tests {
 
     #[test]
     fn test_is_valid_label_name() {
-        let tbl = [
-            ("_",          true ),
-            ("a",          true ),
-            ("_9",         true ),
-            ("a9",         true ),
-            ("a_b_9_dx_",  true ),
-            (":",          false),
-            (":9",         false),
-            ("9",          false),
-            ("9:",         false),
-            ("9_",         false),
-            ("9a",         false),
-            ("a-",         false),
-            ("a_b_9_d:x_", false),
-        ];
+        let tbl = [("_", true),
+                   ("a", true),
+                   ("_9", true),
+                   ("a9", true),
+                   ("a_b_9_dx_", true),
+                   (":", false),
+                   (":9", false),
+                   ("9", false),
+                   ("9:", false),
+                   ("9_", false),
+                   ("9a", false),
+                   ("a-", false),
+                   ("a_b_9_d:x_", false)];
 
         for &(name, expected) in &tbl {
             assert_eq!(is_valid_label_name(name), expected);

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -481,7 +481,7 @@ impl LocalHistogramTimer {
     }
 }
 
-impl<'a> Drop for LocalHistogramTimer {
+impl Drop for LocalHistogramTimer {
     fn drop(&mut self) {
         self.observe()
     }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -452,7 +452,7 @@ pub struct LocalHistogramCore {
 
 /// `LocalHistogram` is used for performance and in single-thread.
 /// Sometimes, if you very care the performance, you can use the `LocalHistogram`
-// and then flush the metric interval.
+/// and then flush the metric interval.
 #[derive(Clone)]
 pub struct LocalHistogram {
     core: Rc<RefCell<LocalHistogramCore>>,

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -16,6 +16,8 @@ use std::convert::From;
 use std::sync::Arc;
 use std::collections::HashMap;
 use std::time::{Instant, Duration};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 use proto;
 use protobuf::RepeatedField;
@@ -306,6 +308,11 @@ impl Histogram {
     pub fn start_timer(&self) -> HistogramTimer {
         HistogramTimer::new(self.clone())
     }
+
+    /// `local` returns a `LocalHistogram` for single thread usage.
+    pub fn local(&self) -> LocalHistogram {
+        LocalHistogram::new(self.clone())
+    }
 }
 
 
@@ -434,6 +441,117 @@ pub fn exponential_buckets(start: f64, factor: f64, count: usize) -> Result<Vec<
 pub fn duration_to_seconds(d: Duration) -> f64 {
     let nanos = d.subsec_nanos() as f64 / 1e9;
     d.as_secs() as f64 + nanos
+}
+
+pub struct LocalHistogramCore {
+    histogram: Histogram,
+    upper_bounds: Vec<f64>,
+    counts: Vec<u64>,
+    count: u64,
+    sum: f64,
+}
+
+/// `LocalHistogram` is used for performance and in single-thread.
+/// Sometimes, if you very care the performance, you can use the LocalHistogram
+// and then flush the metric interval.
+#[derive(Clone)]
+pub struct LocalHistogram {
+    core: Rc<RefCell<LocalHistogramCore>>,
+}
+
+pub struct LocalHistogramTimer {
+    local: LocalHistogram,
+    start: Instant,
+}
+
+/// `LocalHistogramTimer` represents an event being timed. When the timer goes out of
+/// scope, the duration will be observed, or call `observe_duration` to manually
+/// observe.
+///
+/// NOTICE: A timer can be observed only once (automatically or manually).
+impl LocalHistogramTimer {
+    /// `observe_duration` observes the amount of time in seconds since
+    /// `LocalHistogram.start_timer` was called.
+    pub fn observe_duration(self) {
+        drop(self);
+    }
+
+    fn observe(&mut self) {
+        let v = duration_to_seconds(self.start.elapsed());
+        self.local.observe(v)
+    }
+}
+
+impl<'a> Drop for LocalHistogramTimer {
+    fn drop(&mut self) {
+        self.observe()
+    }
+}
+
+impl LocalHistogramCore {
+    fn new(histogram: Histogram) -> LocalHistogramCore {
+        let bounds = histogram.core.upper_bounds.clone();
+        let counts = vec![0;bounds.len()];
+
+        LocalHistogramCore {
+            histogram: histogram,
+            upper_bounds: bounds,
+            counts: counts,
+            count: 0,
+            sum: 0.0,
+        }
+    }
+
+    pub fn observe(&mut self, v: f64) {
+        // Try find the bucket.
+        let mut iter = self.upper_bounds.iter().enumerate().filter(|&(_, f)| v <= *f);
+        if let Some((i, _)) = iter.next() {
+            self.counts[i] += 1;
+        }
+
+        self.count += 1;
+        self.sum += v;
+    }
+
+    pub fn flush(&mut self) {
+        let h = self.histogram.clone();
+
+        for (i, v) in self.counts.iter_mut().enumerate() {
+            h.core.counts[i].inc_by(*v);
+            *v = 0;
+        }
+
+        h.core.count.inc_by(self.count);
+        h.core.sum.inc_by(self.sum);
+
+        self.count = 0;
+        self.sum = 0.0;
+    }
+}
+
+impl LocalHistogram {
+    fn new(histogram: Histogram) -> LocalHistogram {
+        let core = LocalHistogramCore::new(histogram);
+        LocalHistogram { core: Rc::new(RefCell::new(core)) }
+    }
+
+    /// `observe` adds a single observation to the `Histogram`.
+    pub fn observe(&self, v: f64) {
+        self.core.borrow_mut().observe(v);
+    }
+
+    /// `start_timer`
+    pub fn start_timer(&self) -> LocalHistogramTimer {
+        LocalHistogramTimer {
+            local: self.clone(),
+            start: Instant::now(),
+        }
+    }
+
+    /// `flush` flushes the local metric to the Histogram metric.
+    pub fn flush(&self) {
+        self.core.borrow_mut().flush();
+    }
 }
 
 #[cfg(test)]
@@ -586,5 +704,36 @@ mod tests {
         assert_eq!(proto_histogram.get_sample_count(), 1);
         assert!((proto_histogram.get_sample_sum() - 1.0) < EPSILON);
         assert_eq!(proto_histogram.get_bucket().len(), buckets.len())
+    }
+
+    #[test]
+    fn test_histogram_local() {
+        let buckets = vec![1.0, 2.0, 3.0];
+        let opts = HistogramOpts::new("test_histogram_local", "test histogram local help")
+            .buckets(buckets.clone());
+        let histogram = Histogram::with_opts(opts).unwrap();
+        let local = histogram.local();
+
+        local.observe(1.0);
+        local.observe(4.0);
+
+        let m = histogram.metric();
+        let proto_histogram = m.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 0);
+
+        local.flush();
+
+        let m = histogram.metric();
+        let proto_histogram = m.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 2);
+        assert_eq!(proto_histogram.get_sample_sum(), 5.0);
+
+        local.observe(2.0);
+        local.flush();
+
+        let m = histogram.metric();
+        let proto_histogram = m.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 3);
+        assert_eq!(proto_histogram.get_sample_sum(), 7.0);
     }
 }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -445,7 +445,6 @@ pub fn duration_to_seconds(d: Duration) -> f64 {
 
 pub struct LocalHistogramCore {
     histogram: Histogram,
-    upper_bounds: Vec<f64>,
     counts: Vec<u64>,
     count: u64,
     sum: f64,
@@ -490,12 +489,10 @@ impl<'a> Drop for LocalHistogramTimer {
 
 impl LocalHistogramCore {
     fn new(histogram: Histogram) -> LocalHistogramCore {
-        let bounds = histogram.core.upper_bounds.clone();
-        let counts = vec![0;bounds.len()];
+        let counts = vec![0;histogram.core.counts.len()];
 
         LocalHistogramCore {
             histogram: histogram,
-            upper_bounds: bounds,
             counts: counts,
             count: 0,
             sum: 0.0,
@@ -504,7 +501,8 @@ impl LocalHistogramCore {
 
     pub fn observe(&mut self, v: f64) {
         // Try find the bucket.
-        let mut iter = self.upper_bounds.iter().enumerate().filter(|&(_, f)| v <= *f);
+        let mut iter =
+            self.histogram.core.upper_bounds.iter().enumerate().filter(|&(_, f)| v <= *f);
         if let Some((i, _)) = iter.next() {
             self.counts[i] += 1;
         }


### PR DESCRIPTION
If we use metrics frequently, it may reduce the performance. For Counter and Gauge, we can simply use a int value in local and then flush to metric in batch, but it is not easy for histogram.

So we support LocalHistogram, it can be only used in single thread, and you must call `flush` interval to flush to metric. 

Benchmark 

```
test histogram::bench_histogram_local                   ... bench:           8 ns/iter (+/- 2)
test histogram::bench_histogram_local_timer             ... bench:          60 ns/iter (+/- 2)
test histogram::bench_histogram_no_labels               ... bench:          89 ns/iter (+/- 4)
test histogram::bench_histogram_timer                   ... bench:         151 ns/iter (+/- 10)
test histogram::bench_histogram_with_label_values       ... bench:         154 ns/iter (+/- 12)
```

PTAL @overvenus 