### PR TITLE
process: remove tailing whitespace and improve performance

### DIFF
--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -330,22 +330,22 @@ nonvoluntary_ctxt_switches:	68606
     const VM_SIZE: f64 = 1362696.0;
 
     const LIMITS_LITERAL: &'static str = r#"
-Limit                     Soft Limit           Hard Limit           Units     
-Max cpu time              unlimited            unlimited            seconds   
-Max file size             unlimited            unlimited            bytes     
-Max data size             unlimited            unlimited            bytes     
-Max stack size            8388608              unlimited            bytes     
-Max core file size        0                    unlimited            bytes     
-Max resident set          unlimited            unlimited            bytes     
-Max processes             31454                31454                processes 
-Max open files            1024                 4096                 files     
-Max locked memory         65536                65536                bytes     
-Max address space         unlimited            unlimited            bytes     
-Max file locks            unlimited            unlimited            locks     
-Max pending signals       31454                31454                signals   
-Max msgqueue size         819200               819200               bytes     
-Max nice priority         0                    0                    
-Max realtime priority     0                    0                    
+Limit                     Soft Limit           Hard Limit           Units
+Max cpu time              unlimited            unlimited            seconds
+Max file size             unlimited            unlimited            bytes
+Max data size             unlimited            unlimited            bytes
+Max stack size            8388608              unlimited            bytes
+Max core file size        0                    unlimited            bytes
+Max resident set          unlimited            unlimited            bytes
+Max processes             31454                31454                processes
+Max open files            1024                 4096                 files
+Max locked memory         65536                65536                bytes
+Max address space         unlimited            unlimited            bytes
+Max file locks            unlimited            unlimited            locks
+Max pending signals       31454                31454                signals
+Max msgqueue size         819200               819200               bytes
+Max nice priority         0                    0
+Max realtime priority     0                    0
 Max realtime timeout      unlimited            unlimited            us "#;
 
     const MAXFD: f64 = 1024.0;

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -197,13 +197,11 @@ fn open_fds(pid: pid_t) -> Result<usize> {
 //
 // pub for tests.
 pub fn find_statistic(all: &str, pat: &str) -> Result<f64> {
-    for line in all.lines() {
-        if let Some(idx) = line.find(pat) {
-            let mut iter = (line[idx + pat.len()..]).split_whitespace();
-            if let Some(v) = iter.next() {
-                return v.parse()
-                    .map_err(|e| Error::Msg(format!("read statistic {} failed: {}", pat, e)));
-            }
+    if let Some(idx) = all.find(pat) {
+        let mut iter = (all[idx + pat.len()..]).split_whitespace();
+        if let Some(v) = iter.next() {
+            return v.parse()
+                .map_err(|e| Error::Msg(format!("read statistic {} failed: {}", pat, e)));
         }
     }
 


### PR DESCRIPTION
Actual limits has tailing whitespace, which rustfmt warns, this PR remove those, since they are not correctness-related.  

https://github.com/rust-lang-nursery/rustfmt/issues/1220

PTAL @siddontang @disksing 