### PR TITLE
histogram: add a fast coarse timer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 [features]
 default = []
 dev = ["clippy"]
-nightly = []
+nightly = ["libc"]
 push = ["hyper", "libc"]
 process = ["libc", "procinfo"]
 

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -41,7 +41,7 @@ fn bench_histogram_timer(b: &mut Bencher) {
 }
 
 #[bench]
-#[cfg(all(feature="nightly", target_os="linux"))]
+#[cfg(feature="nightly")]
 fn bench_histogram_coarse_timer(b: &mut Bencher) {
     let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
                                                             "A histogram to benchmark it."))
@@ -70,7 +70,7 @@ fn bench_local_histogram_timer(b: &mut Bencher) {
 }
 
 #[bench]
-#[cfg(all(feature="nightly", target_os="linux"))]
+#[cfg(feature="nightly")]
 fn bench_local_histogram_coarse_timer(b: &mut Bencher) {
     let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
                                                             "A histogram to benchmark it."))

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -41,6 +41,15 @@ fn bench_histogram_timer(b: &mut Bencher) {
 }
 
 #[bench]
+#[cfg(all(feature="nightly", target_os="linux"))]
+fn bench_histogram_coarse_timer(b: &mut Bencher) {
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
+                                                            "A histogram to benchmark it."))
+        .unwrap();
+    b.iter(|| histogram.start_coarse_timer())
+}
+
+#[bench]
 fn bench_histogram_local(b: &mut Bencher) {
     let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_local",
                                                             "A histogram to benchmark it."))
@@ -51,11 +60,22 @@ fn bench_histogram_local(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_histogram_local_timer(b: &mut Bencher) {
+fn bench_local_histogram_timer(b: &mut Bencher) {
     let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_local_timer",
                                                             "A histogram to benchmark it."))
         .unwrap();
     let local = histogram.local();
     b.iter(|| local.start_timer());
+    local.flush();
+}
+
+#[bench]
+#[cfg(all(feature="nightly", target_os="linux"))]
+fn bench_local_histogram_coarse_timer(b: &mut Bencher) {
+    let histogram = Histogram::with_opts(HistogramOpts::new("benchmark_histogram_timer",
+                                                            "A histogram to benchmark it."))
+        .unwrap();
+    let local = histogram.local();
+    b.iter(|| local.start_coarse_timer());
     local.flush();
 }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -15,9 +15,12 @@
 use std::convert::From;
 use std::sync::Arc;
 use std::collections::HashMap;
-use std::time::{Instant, Duration};
+use std::time::{Instant as StdInstant, Duration};
 use std::cell::RefCell;
 use std::rc::Rc;
+
+#[cfg(all(feature="nightly", target_os="linux"))]
+use libc::{clock_gettime, CLOCK_MONOTONIC_COARSE, timespec, clock_t};
 
 use proto;
 use protobuf::RepeatedField;
@@ -229,6 +232,55 @@ impl HistogramCore {
     }
 }
 
+enum Instant {
+    Monotonic(StdInstant),
+    #[cfg(all(feature="nightly", target_os="linux"))]
+    MonotonicCoarse(timespec),
+}
+
+impl Instant {
+    fn now() -> Instant {
+        Instant::Monotonic(StdInstant::now())
+    }
+
+    #[cfg(all(feature="nightly", target_os="linux"))]
+    fn now_coarse() -> Instant {
+        Instant::MonotonicCoarse(get_time(CLOCK_MONOTONIC_COARSE as clock_t))
+    }
+
+    fn elapsed(&self) -> Duration {
+        match *self {
+            Instant::Monotonic(i) => i.elapsed(),
+
+            #[cfg(all(feature="nightly", target_os="linux"))]
+            Instant::MonotonicCoarse(t) => {
+                const NANOS_PER_SEC: f64 = 1_000_000_000.0;
+                let now = get_time(CLOCK_MONOTONIC_COARSE as clock_t);
+                if now.tv_sec > t.tv_sec || (now.tv_sec == t.tv_sec && now.tv_nsec >= t.tv_nsec) {
+                    Duration::new((t.tv_sec - now.tv_sec) as u64,
+                                  (t.tv_nsec - now.tv_nsec) as u32)
+                } else {
+                    panic!("system time jumped back, {:.9} -> {:.9}",
+                           t.tv_sec as f64 + t.tv_nsec as f64 / NANOS_PER_SEC,
+                           now.tv_sec as f64 + now.tv_nsec as f64 / NANOS_PER_SEC);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(all(feature="nightly", target_os="linux"))]
+fn get_time(clock: clock_t) -> timespec {
+    let mut t = timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+
+    let errno = unsafe { clock_gettime(clock as i32, &mut t) };
+    assert_eq!(errno, 0);
+    t
+}
+
 /// `HistogramTimer` represents an event being timed. When the timer goes out of
 /// scope, the duration will be observed, or call `observe_duration` to manually
 /// observe.
@@ -244,6 +296,14 @@ impl HistogramTimer {
         HistogramTimer {
             histogram: histogram,
             start: Instant::now(),
+        }
+    }
+
+    #[cfg(all(feature="nightly", target_os="linux"))]
+    fn new_coarse(histogram: Histogram) -> HistogramTimer {
+        HistogramTimer {
+            histogram: histogram,
+            start: Instant::now_coarse(),
         }
     }
 
@@ -307,6 +367,13 @@ impl Histogram {
     /// `start_timer` returns a `HistogramTimer` to track a duration.
     pub fn start_timer(&self) -> HistogramTimer {
         HistogramTimer::new(self.clone())
+    }
+
+    /// `start_coarse_timer` returns a `HistogramTimer` to track a duration,
+    /// it is faster but less precise.
+    #[cfg(all(feature="nightly", target_os="linux"))]
+    pub fn start_coarse_timer(&self) -> HistogramTimer {
+        HistogramTimer::new_coarse(self.clone())
     }
 
     /// `local` returns a `LocalHistogram` for single thread usage.
@@ -562,6 +629,16 @@ impl LocalHistogram {
         }
     }
 
+    /// `start_coarse_timer` returns a `LocalHistogramTimer` to track a duration.
+    /// it is faster but less precise.
+    #[cfg(all(feature="nightly", target_os="linux"))]
+    pub fn start_coarse_timer(&self) -> LocalHistogramTimer {
+        LocalHistogramTimer {
+            local: self.clone(),
+            start: Instant::now_coarse(),
+        }
+    }
+
     /// `clear` clears the local metric.
     pub fn clear(&self) {
         self.core.borrow_mut().clear();
@@ -633,6 +710,33 @@ mod tests {
         assert_eq!(proto_histogram.get_sample_count(), 0);
         assert!((proto_histogram.get_sample_sum() - 0.0) < EPSILON);
         assert_eq!(proto_histogram.get_bucket().len(), buckets.len())
+    }
+
+    #[test]
+    #[cfg(all(feature="nightly", target_os="linux"))]
+    fn test_histogram_coarse_timer() {
+        let opts = HistogramOpts::new("test1", "test help");
+        let histogram = Histogram::with_opts(opts).unwrap();
+
+        let timer = histogram.start_coarse_timer();
+        thread::sleep(Duration::from_millis(100));
+        timer.observe_duration();
+
+        let timer = histogram.start_coarse_timer();
+        let handler = thread::spawn(move || {
+            let _timer = timer;
+            thread::sleep(Duration::from_millis(400));
+        });
+        assert!(handler.join().is_ok());
+
+        let mut mfs = histogram.collect();
+        assert_eq!(mfs.len(), 1);
+
+        let mf = mfs.pop().unwrap();
+        let m = mf.get_metric().as_ref().get(0).unwrap();
+        let proto_histogram = m.get_histogram();
+        assert_eq!(proto_histogram.get_sample_count(), 2);
+        assert!((proto_histogram.get_sample_sum() - 0.0) > EPSILON);
     }
 
     #[test]

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -19,7 +19,7 @@ use std::time::{Instant as StdInstant, Duration};
 use std::cell::RefCell;
 use std::rc::Rc;
 
-#[cfg(feature="nightly")]
+#[cfg(all(feature="nightly", target_os="linux"))]
 use libc::{clock_gettime, CLOCK_MONOTONIC_COARSE, timespec, clock_t};
 
 use proto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 
 #![cfg_attr(feature="dev", feature(plugin))]
 #![cfg_attr(feature="dev", plugin(clippy))]
-#![cfg_attr(feature="nightly", feature(integer_atomics, libc))]
+#![cfg_attr(feature="nightly", feature(integer_atomics))]
 
 // Allow zero_ptr, caused by lazy_static.
 // Clippy warns `zero_ptr` and suggests using `std::ptr::null`, but

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 
 #![cfg_attr(feature="dev", feature(plugin))]
 #![cfg_attr(feature="dev", plugin(clippy))]
-#![cfg_attr(feature="nightly", feature(integer_atomics))]
+#![cfg_attr(feature="nightly", feature(integer_atomics, libc))]
 
 // Allow zero_ptr, caused by lazy_static.
 // Clippy warns `zero_ptr` and suggests using `std::ptr::null`, but
@@ -28,7 +28,7 @@ extern crate fnv;
 extern crate lazy_static;
 #[cfg(feature="push")]
 extern crate hyper;
-#[cfg(any(feature="push", feature="process"))]
+#[cfg(any(feature="nightly", feature="push", feature="process"))]
 extern crate libc;
 #[cfg(all(feature = "process", target_os="linux"))]
 extern crate procinfo;
@@ -54,7 +54,6 @@ mod histogram;
 #[cfg(feature="push")]
 mod push;
 mod atomic64;
-pub mod local;
 
 // Mods
 
@@ -63,6 +62,7 @@ pub mod local;
 pub mod proto;
 #[cfg(all(feature = "process", target_os="linux"))]
 pub mod process_collector;
+pub mod local;
 
 // Traits
 pub use self::encoder::Encoder;


### PR DESCRIPTION
Coarse timer uses [`CLOCK_MONOTONIC_COARSE`](https://linux.die.net/man/2/clock_gettime), it is faster but less precise, and linux only.

Benchmark
```
test histogram::bench_histogram_coarse_timer            ... bench:          48 ns/iter (+/- 0)
test histogram::bench_histogram_timer                   ... bench:          86 ns/iter (+/- 0)

test histogram::bench_local_histogram_coarse_timer      ... bench:          48 ns/iter (+/- 0)
test histogram::bench_local_histogram_timer             ... bench:          85 ns/iter (+/- 0)
```