### PR TITLE
histgram: use millisecond resolution for coarse timer

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -754,18 +754,13 @@ mod tests {
     #[cfg(feature="nightly")]
     fn test_instant_on_smp() {
         for i in 0..100000 {
-            let now = Instant::now_coarse();
-            if i % 100 == 0 {
-                thread::yield_now();
-            }
-            now.elapsed();
-        }
-        for i in 0..100000 {
             let now = Instant::now();
+            let now_coarse = Instant::now_coarse();
             if i % 100 == 0 {
                 thread::yield_now();
             }
             now.elapsed();
+            now_coarse.elapsed();
         }
     }
 

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -265,7 +265,7 @@ impl Instant {
                 let now_ms = now.tv_sec * MILLIS_PER_SEC + now.tv_nsec / NANOS_PER_MILLI;
                 let t_ms = t.tv_sec * MILLIS_PER_SEC + t.tv_nsec / NANOS_PER_MILLI;
                 let dur = now_ms - t_ms;
-                if dur >= *CORASE_ERROR {
+                if dur >= -*CORASE_ERROR {
                     Duration::from_millis(if dur > 0 { dur as u64 } else { 0 })
                 } else {
                     panic!("system time jumped back, {:.3} -> {:.3}",
@@ -306,7 +306,7 @@ mod coarse {
                 tv_nsec: 0,
             };
             assert_eq!(unsafe { clock_getres(CLOCK_MONOTONIC_COARSE, &mut t) }, 0);
-            - t.tv_nsec / NANOS_PER_MILLI
+            t.tv_nsec / NANOS_PER_MILLI
         };
     }
 }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -261,6 +261,7 @@ impl Instant {
             // The processors in an SMP system do not start all at exactly the same time
             // and therefore the timer registers are typically running at an offset.
             // Use millisecond resolution for ignoring the error.
+            // See more: https://linux.die.net/man/2/clock_gettime
             #[cfg(all(feature="nightly", target_os="linux"))]
             Instant::MonotonicCoarse(t) => {
                 const NANOS_PER_SEC: f64 = 1_000_000_000.0;

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -772,7 +772,7 @@ mod tests {
     #[test]
     #[cfg(feature="nightly")]
     fn test_instant_on_smp() {
-        for i in 0..100000 {
+        for i in 0..100_000 {
             let now = Instant::now();
             let now_coarse = Instant::now_coarse();
             if i % 100 == 0 {


### PR DESCRIPTION
The processors in an SMP system do not start all at exactly the same time
and therefore the timer registers are typically running at an offset.
Use millisecond resolution for ignoring the error.

CC pingcap/tikv#2165