### PR TITLE
Add public export for MetricVec

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub use self::metrics::Opts;
 pub use self::counter::{Counter, CounterVec};
 pub use self::gauge::{Gauge, GaugeVec};
 pub use self::histogram::{Histogram, HistogramVec, HistogramOpts, HistogramTimer};
+pub use self::vec::MetricVec;
 
 // Functions
 pub use self::registry::{gather, register, unregister};


### PR DESCRIPTION
[The existing docs for CounterVec](https://docs.rs/prometheus/0.3.1/prometheus/type.CounterVec.html) (and GaugeVec/HistogramVec) don't show that `fn new(...)` exists, and `MetricVec` isn't clickable, so you can't tell what methods exist (but you can still call them if you already know what they are).

This exports MetricVec publicly, so things show up in the docs correctly.