### PR TITLE
Fixed typo in example_push file

### DIFF
--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -44,7 +44,7 @@ fn main() {
     let program = args[0].clone();
 
     let mut opts = Options::new();
-    opts.optopt(
+    opts.optflagopt(
         "A",
         "addr",
         "prometheus pushgateway address",


### PR DESCRIPTION
**Fixed before run:**

**./example_push -A**
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ArgumentMissing("A")', /checkout/src/libcore/result.rs:906:4
note: Run with `RUST_BACKTRACE=1` for a backtrace.

