### PR TITLE
Use rustfmt 0.3.4 to format the code

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -13,8 +13,8 @@
 
 #![feature(test)]
 
-extern crate test;
 extern crate prometheus;
+extern crate test;
 
 mod counter;
 mod gauge;

--- a/benches/counter.rs
+++ b/benches/counter.rs
@@ -11,10 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use prometheus::{Counter, CounterVec, Opts};
 use std::collections::HashMap;
-
 use test::Bencher;
 
 #[bench]
@@ -23,9 +21,7 @@ fn bench_counter_with_label_values(b: &mut Bencher) {
         Opts::new("benchmark_counter", "A counter to benchmark it."),
         &["one", "two", "three"],
     ).unwrap();
-    b.iter(|| {
-        counter.with_label_values(&["eins", "zwei", "drei"]).inc()
-    })
+    b.iter(|| counter.with_label_values(&["eins", "zwei", "drei"]).inc())
 }
 
 #[bench]
@@ -56,7 +52,9 @@ fn bench_counter_with_prepared_mapped_labels(b: &mut Bencher) {
     labels.insert("one", "eins");
     labels.insert("three", "drei");
 
-    b.iter(|| { counter.with(&labels).inc(); })
+    b.iter(|| {
+        counter.with(&labels).inc();
+    })
 }
 
 #[bench]

--- a/benches/gauge.rs
+++ b/benches/gauge.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use prometheus::{Gauge, GaugeVec, Opts};
 use test::Bencher;
 

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use prometheus::{Histogram, HistogramOpts, HistogramVec};
 use test::Bencher;
 

--- a/examples/example_embed.rs
+++ b/examples/example_embed.rs
@@ -13,7 +13,6 @@
 
 extern crate prometheus;
 
-
 use prometheus::{Counter, CounterVec, Encoder, Gauge, GaugeVec, Opts, Registry, TextEncoder};
 use std::thread;
 use std::time::Duration;
@@ -74,20 +73,24 @@ fn main() {
     let cv2 = counter_vec.clone();
     let g2 = gauge.clone();
     let gv2 = gauge_vec.clone();
-    thread::spawn(move || for _ in 0..10 {
-        thread::sleep(Duration::from_millis(500));
-        c2.inc();
-        cv2.with_label_values(&["3", "4"]).inc();
-        g2.inc();
-        gv2.with_label_values(&["3", "4"]).inc();
+    thread::spawn(move || {
+        for _ in 0..10 {
+            thread::sleep(Duration::from_millis(500));
+            c2.inc();
+            cv2.with_label_values(&["3", "4"]).inc();
+            g2.inc();
+            gv2.with_label_values(&["3", "4"]).inc();
+        }
     });
 
-    thread::spawn(move || for _ in 0..5 {
-        thread::sleep(Duration::from_secs(1));
-        counter.inc();
-        counter_vec.with_label_values(&["3", "4"]).inc();
-        gauge.dec();
-        gauge_vec.with_label_values(&["3", "4"]).set(42.0);
+    thread::spawn(move || {
+        for _ in 0..5 {
+            thread::sleep(Duration::from_secs(1));
+            counter.inc();
+            counter_vec.with_label_values(&["3", "4"]).inc();
+            gauge.dec();
+            gauge_vec.with_label_values(&["3", "4"]).set(42.0);
+        }
     });
 
     // Choose your writer and encoder.

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -11,16 +11,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[macro_use]
-extern crate prometheus;
 extern crate hyper;
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate prometheus;
 
 use hyper::header::ContentType;
 use hyper::mime::Mime;
 use hyper::server::{Request, Response, Server};
-
 use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder};
 
 lazy_static! {

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -15,10 +15,9 @@ extern crate prometheus;
 
 #[cfg(all(feature = "process", target_os = "linux"))]
 fn main() {
+    use prometheus::{self, Encoder};
     use std::thread;
     use std::time::Duration;
-
-    use prometheus::{self, Encoder};
 
     // A default ProcessCollector is registered automatically.
     let mut buffer = Vec::new();

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -13,12 +13,11 @@
 
 #![cfg_attr(not(feature = "push"), allow(unused_imports, dead_code))]
 
-#[macro_use]
-extern crate prometheus;
+extern crate getopts;
 #[macro_use]
 extern crate lazy_static;
-extern crate getopts;
-
+#[macro_use]
+extern crate prometheus;
 
 use getopts::Options;
 use prometheus::{Counter, Histogram};

--- a/src/atomic64.rs
+++ b/src/atomic64.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #[cfg(feature = "nightly")]
 pub use self::atomic::{AtomicF64, AtomicU64};
 #[cfg(not(feature = "nightly"))]
@@ -103,8 +102,9 @@ mod atomic {
             loop {
                 let current = self.inner.load(Ordering::Acquire);
                 let new = u64_to_f64(current) + delta;
-                let swapped = self.inner
-                    .compare_and_swap(current, f64_to_u64(new), Ordering::Release);
+                let swapped =
+                    self.inner
+                        .compare_and_swap(current, f64_to_u64(new), Ordering::Release);
                 if swapped == current {
                     return;
                 }

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 use errors::{Error, Result};
-
 use fnv::FnvHasher;
 use metrics::SEPARATOR_BYTE;
-
 use proto::LabelPair;
 use std::collections::{BTreeSet, HashMap};
 use std::hash::Hasher;
@@ -126,9 +124,10 @@ impl Desc {
         }
 
         if !is_valid_metric_name(&desc.fq_name) {
-            return Err(Error::Msg(
-                format!("'{}' is not a valid metric name", desc.fq_name),
-            ));
+            return Err(Error::Msg(format!(
+                "'{}' is not a valid metric name",
+                desc.fq_name
+            )));
         }
 
         let mut label_values = Vec::with_capacity(const_labels.len() + 1);
@@ -138,15 +137,17 @@ impl Desc {
 
         for label_name in const_labels.keys() {
             if !is_valid_label_name(label_name) {
-                return Err(Error::Msg(
-                    format!("'{}' is not a valid label name", &label_name),
-                ));
+                return Err(Error::Msg(format!(
+                    "'{}' is not a valid label name",
+                    &label_name
+                )));
             }
 
             if !label_names.insert(label_name.clone()) {
-                return Err(Error::Msg(
-                    format!("duplicate const label name {}", label_name),
-                ));
+                return Err(Error::Msg(format!(
+                    "duplicate const label name {}",
+                    label_name
+                )));
             }
         }
 
@@ -160,15 +161,17 @@ impl Desc {
         // dimension with a different mix between preset and variable labels.
         for label_name in &desc.variable_labels {
             if !is_valid_label_name(label_name) {
-                return Err(Error::Msg(
-                    format!("'{}' is not a valid label name", &label_name),
-                ));
+                return Err(Error::Msg(format!(
+                    "'{}' is not a valid label name",
+                    &label_name
+                )));
             }
 
             if !label_names.insert(format!("${}", label_name)) {
-                return Err(Error::Msg(
-                    format!("duplicate variable label name {}", label_name),
-                ));
+                return Err(Error::Msg(format!(
+                    "duplicate variable label name {}",
+                    label_name
+                )));
             }
         }
 

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use errors::{Error, Result};
 use proto::MetricFamily;
 use std::io::Write;

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -11,12 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use super::{check_metric_family, Encoder};
-
 use errors::Result;
 use proto::MetricFamily;
-
 use protobuf::Message;
 use std::io::Write;
 

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -11,9 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use super::{check_metric_family, Encoder};
-
 use errors::Result;
 use histogram::BUCKET_LABEL;
 use proto::{self, MetricType};

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use protobuf::error::ProtobufError;
 use std::io::Error as IoError;
 use std::result;

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -15,7 +15,6 @@
 use desc::Desc;
 use errors::Result;
 use metrics::{Collector, Metric, Opts};
-
 use proto;
 use std::sync::Arc;
 use value::{Value, ValueType};
@@ -137,7 +136,6 @@ impl GaugeVec {
 mod tests {
 
     use super::*;
-
     use metrics::{Collector, Opts};
     use std::collections::HashMap;
 

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -12,13 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use atomic64::{AtomicF64, AtomicU64};
 use desc::{Desc, Describer};
 use errors::{Error, Result};
 use metrics::{Collector, Metric, Opts};
 use proto;
-
 use protobuf::RepeatedField;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -33,17 +31,7 @@ use vec::{MetricVec, MetricVecBuilder};
 /// network service. Most likely, however, you will be required to define
 /// buckets customized to your use case.
 pub const DEFAULT_BUCKETS: &[f64; 11] = &[
-    0.005,
-    0.01,
-    0.025,
-    0.05,
-    0.1,
-    0.25,
-    0.5,
-    1.0,
-    2.5,
-    5.0,
-    10.0,
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0
 ];
 
 /// `BUCKET_LABEL` is used for the label that defines the upper bound of a
@@ -249,8 +237,7 @@ impl HistogramCore {
 
 enum Instant {
     Monotonic(StdInstant),
-    #[cfg(all(feature = "nightly", target_os = "linux"))]
-    MonotonicCoarse(timespec),
+    #[cfg(all(feature = "nightly", target_os = "linux"))] MonotonicCoarse(timespec),
 }
 
 impl Instant {
@@ -299,7 +286,6 @@ use self::coarse::*;
 #[cfg(all(feature = "nightly", target_os = "linux"))]
 mod coarse {
     use libc::{clock_gettime, CLOCK_MONOTONIC_COARSE};
-
     pub use libc::timespec;
 
     pub const NANOS_PER_MILLI: i64 = 1_000_000;
@@ -419,7 +405,6 @@ impl Histogram {
     }
 }
 
-
 impl Metric for Histogram {
     fn metric(&self) -> proto::Metric {
         let mut m = proto::Metric::new();
@@ -481,7 +466,7 @@ impl HistogramVec {
 
     pub fn local(&self) -> LocalHistogramVec {
         let vec = self.clone();
-        LocalHistogramVec::new( vec)
+        LocalHistogramVec::new(vec)
     }
 }
 
@@ -775,7 +760,6 @@ impl Clone for LocalHistogramVec {
 mod tests {
 
     use super::*;
-
     use metrics::Collector;
     use metrics::Metric;
     use std::f64::{EPSILON, INFINITY};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,19 +18,19 @@
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
 
 #[macro_use]
-extern crate quick_error;
-extern crate protobuf;
+extern crate cfg_if;
 extern crate fnv;
-#[macro_use]
-extern crate lazy_static;
 #[cfg(feature = "push")]
 extern crate hyper;
+#[macro_use]
+extern crate lazy_static;
 #[cfg(any(feature = "nightly", feature = "push", feature = "process"))]
 extern crate libc;
 #[cfg(all(feature = "process", target_os = "linux"))]
 extern crate procinfo;
+extern crate protobuf;
 #[macro_use]
-extern crate cfg_if;
+extern crate quick_error;
 extern crate spin;
 
 mod errors;

--- a/src/local.rs
+++ b/src/local.rs
@@ -14,5 +14,5 @@
 
 // TODO: define a trait and implement the trait for metrics.
 
-pub use super::counter::{LocalCounter};
+pub use super::counter::LocalCounter;
 pub use super::histogram::{LocalHistogram, LocalHistogramTimer, LocalHistogramVec};

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use desc::{Desc, Describer};
 use errors::Result;
 use proto::{self, LabelPair};

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -19,14 +19,11 @@ use counter::Counter;
 use desc::Desc;
 use errors::{Error, Result};
 use gauge::Gauge;
-
 use libc;
-
 /// The `pid_t` data type represents process IDs.
 pub use libc::pid_t;
 use metrics::{Collector, Opts};
 use procinfo::pid as pid_info;
-
 use proto;
 use std::fs;
 use std::io::Read;
@@ -209,9 +206,8 @@ fn find_statistic(all: &str, pat: &str) -> Result<f64> {
     if let Some(idx) = all.find(pat) {
         let mut iter = (all[idx + pat.len()..]).split_whitespace();
         if let Some(v) = iter.next() {
-            return v.parse().map_err(|e| {
-                Error::Msg(format!("read statistic {} failed: {}", pat, e))
-            });
+            return v.parse()
+                .map_err(|e| Error::Msg(format!("read statistic {} failed: {}", pat, e)));
         }
     }
 
@@ -262,7 +258,6 @@ mod tests {
 
     use super::*;
     use metrics::Collector;
-
     use registry;
     use std::f64::EPSILON;
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -14,14 +14,12 @@
 
 use encoder::{Encoder, ProtobufEncoder};
 use errors::{Error, Result};
-
 use hyper::client::Client;
 use hyper::client::pool::Config;
 use hyper::header::ContentType;
 use hyper::method::Method;
 use hyper::status::StatusCode;
 use metrics::Collector;
-
 use proto;
 use registry::Registry;
 use std::collections::HashMap;
@@ -89,7 +87,6 @@ fn push<S: BuildHasher>(
     mfs: Vec<proto::MetricFamily>,
     method: &str,
 ) -> Result<()> {
-
     // Suppress clippy warning needless_pass_by_value.
     let grouping = grouping;
 
@@ -116,8 +113,7 @@ fn push<S: BuildHasher>(
         if lv.contains('/') {
             return Err(Error::Msg(format!(
                 "value of grouping label {} contains '/': {}",
-                ln,
-                lv
+                ln, lv
             )));
         }
         url_components.push(ln.to_owned());
@@ -164,8 +160,7 @@ fn push<S: BuildHasher>(
         StatusCode::Accepted => Ok(()),
         _ => Err(Error::Msg(format!(
             "unexpected status code {} while pushing to {}",
-            response.status,
-            push_url
+            response.status, push_url
         ))),
     }
 }
@@ -254,7 +249,6 @@ mod tests {
 
     use super::*;
     use proto;
-
     use protobuf::RepeatedField;
     use std::error::Error;
 

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -14,7 +14,6 @@
 
 use errors::{Error, Result};
 use metrics::Collector;
-
 use proto;
 use spin::RwLock;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -98,9 +97,10 @@ impl RegistryCore {
         }
 
         if self.colloctors_by_id.remove(&collector_id).is_none() {
-            return Err(Error::Msg(
-                format!("collector {:?} is not registered", c.desc()),
-            ));
+            return Err(Error::Msg(format!(
+                "collector {:?} is not registered",
+                c.desc()
+            )));
         }
 
         // dim_hashes_by_name is left untouched as those must be consistent
@@ -284,7 +284,6 @@ pub fn gather() -> Vec<proto::MetricFamily> {
 mod tests {
 
     use super::*;
-
     use counter::{Counter, CounterVec};
     use desc::Desc;
     use metrics::{Collector, Opts};
@@ -434,13 +433,13 @@ mod tests {
             Counter::new("c2", "c2 is a counter").unwrap(),
         ];
 
-        let descs = counters
-            .iter()
-            .map(|c| c.desc().into_iter().cloned())
-            .fold(Vec::new(), |mut acc, ds| {
+        let descs = counters.iter().map(|c| c.desc().into_iter().cloned()).fold(
+            Vec::new(),
+            |mut acc, ds| {
                 acc.extend(ds);
                 acc
-            });
+            },
+        );
 
         let mc = MultipleCollector {
             descs: descs,

--- a/src/value.rs
+++ b/src/value.rs
@@ -15,7 +15,6 @@
 use atomic64::AtomicF64;
 use desc::{Desc, Describer};
 use errors::{Error, Result};
-
 use proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
 use protobuf::RepeatedField;
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use desc::{Desc, Describer};
 use errors::{Error, Result};
-
 use fnv::FnvHasher;
 use metrics::{Collector, Metric};
 use proto::{MetricFamily, MetricType};
@@ -135,9 +133,10 @@ impl<T: MetricVecBuilder> MetricVecCore<T> {
             match labels.get(&name.as_ref()) {
                 Some(val) => h.write(val.as_bytes()),
                 None => {
-                    return Err(Error::Msg(
-                        format!("label name {} missing in label map", name),
-                    ))
+                    return Err(Error::Msg(format!(
+                        "label name {} missing in label map",
+                        name
+                    )))
                 }
             }
         }
@@ -151,9 +150,10 @@ impl<T: MetricVecBuilder> MetricVecCore<T> {
             match labels.get(&name.as_ref()) {
                 Some(val) => values.push(*val),
                 None => {
-                    return Err(Error::Msg(
-                        format!("label name {} missing in label map", name),
-                    ))
+                    return Err(Error::Msg(format!(
+                        "label name {} missing in label map",
+                        name
+                    )))
                 }
             }
         }
@@ -284,13 +284,11 @@ impl<T: MetricVecBuilder> MetricVec<T> {
         self.v.delete(labels)
     }
 
-
     /// `reset` deletes all metrics in this vector.
     pub fn reset(&self) {
         self.v.reset()
     }
 }
-
 
 impl<T: MetricVecBuilder> Collector for MetricVec<T> {
     fn desc(&self) -> Vec<&Desc> {


### PR DESCRIPTION
TiKV has updated to rustfmt-nightly 0.3.4. We need to track this version.