### PR TITLE
Ignore clippy build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,22 @@ env:
     - FEATURES="push process"
     - ARCH=i686
 
+matrix:
+  fast_finish: true
+  include:
+  - env: LINT="dev"
+  allow_failures:
+  - env: LINT="dev"
+
 script:
   # Test common features.
   - cargo test --features="$FEATURES"
   - |
     if [ $TRAVIS_RUST_VERSION = 'nightly' ]; then
         # Enable dev for clippy linting.
-        cargo test --features="$FEATURES dev";
+        cargo test --features="$FEATURES $LINT";
         # Lint nightly feature.
-        cargo test --features="$FEATURES nightly dev";
+        cargo test --features="$FEATURES $LINT nightly";
     fi
   - |
     if [ $TRAVIS_RUST_VERSION = 'stable' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ matrix:
   fast_finish: true
   include:
   - env: LINT="dev"
+    rust: nightly
   allow_failures:
   - env: LINT="dev"
 


### PR DESCRIPTION
This PR adds an allow-failed build job and enables clippy lint on the job only. Now, annoy compile errors will not fail the whole ci. 