### PR TITLE
WIP: Counter Refine

### DIFF
--- a/src/counter/counter.rs
+++ b/src/counter/counter.rs
@@ -1,0 +1,84 @@
+// Copyright 2014 The Prometheus Authors
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::{Result, Error};
+use value::{Value, ValueType};
+use metrics::{Collector, Metric, Opts};
+use desc::Desc;
+use proto;
+use super::*;
+
+/// `Counter` is a Metric that represents a single numerical value that only ever
+/// goes up.
+#[derive(Clone)]
+pub struct Counter {
+    v: Arc<Value>,
+}
+
+impl Counter {
+    /// `new` creates a `Counter` with the `name` and `help` arguments.
+    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Counter> {
+        let opts = Opts::new(name, help);
+        Counter::with_opts(opts)
+    }
+
+    /// `with_opts` creates a `Counter` with the `opts` options.
+    pub fn with_opts(opts: Opts) -> Result<Counter> {
+        Counter::with_opts_and_label_values(&opts, &[])
+    }
+
+    fn with_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> Result<Counter> {
+        let v = Value::new(opts, ValueType::Counter, 0.0, label_values)?;
+        Ok(Counter { v: Arc::new(v) })
+    }
+
+    pub fn local(&self) -> LocalCounter {
+        LocalCounter::new(self.clone())
+    }
+}
+
+impl ICounter for Counter {
+    #[inline]
+    fn try_inc_by(&mut self, v: f64) -> Result<()> {
+        if v < 0.0 {
+            return Err(Error::DecreaseCounter(v));
+        }
+        self.v.inc_by(v);
+        Ok(())
+    }
+
+    fn get(&self) -> f64 {
+        self.v.get()
+    }
+
+    fn reset(&mut self) {
+        panic("Non-local counter cannot be reset");
+    }
+}
+
+impl Collector for Counter {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.v.desc]
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        vec![self.v.collect()]
+    }
+}
+
+impl Metric for Counter {
+    fn metric(&self) -> proto::Metric {
+        self.v.metric()
+    }
+}

--- a/src/counter/local_counter.rs
+++ b/src/counter/local_counter.rs
@@ -1,0 +1,54 @@
+// Copyright 2014 The Prometheus Authors
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::*;
+
+#[derive(Clone)]
+pub struct LocalCounter {
+    counter: Counter,
+    primitive: LocalCounterPrimitive,
+}
+
+// LocalCounter is a thread local copy of Counter
+impl LocalCounter {
+    pub fn new(counter: Counter) -> LocalCounter {
+        LocalCounter {
+            counter,
+            primitive: LocalCounterPrimitive::new(),
+        }
+    }
+
+    /// Flush the metrics to the associated non-local Counter.
+    #[inline]
+    pub fn flush(&mut self) {
+        self.primitive.flush_to(self.counter);
+    }
+}
+
+impl ICounter for LocalCounter {
+    #[inline]
+    fn try_inc_by(&mut self, v: f64) -> Result<()> {
+        self.primitive.try_inc_by(v)
+    }
+
+    #[inline]
+    fn get(&self) -> f64 {
+        self.primitive.get()
+    }
+
+    #[inline]
+    fn reset(&mut self) {
+        self.primitive.reset()
+    }
+}

--- a/src/counter/local_counter_primitive.rs
+++ b/src/counter/local_counter_primitive.rs
@@ -29,6 +29,7 @@ impl LocalCounterPrimitive {
 }
 
 impl ICounter for LocalCounterPrimitive {
+    #[inline]
     fn try_inc_by(&mut self, v: f64) -> Result<()> {
         if v < 0.0 {
             return Err(Error::DecreaseCounter(v));
@@ -37,10 +38,12 @@ impl ICounter for LocalCounterPrimitive {
         Ok(())
     }
 
+    #[inline]
     fn get(&self) -> f64 {
         self.val
     }
 
+    #[inline]
     fn reset(&mut self) {
         self.val = 0.0;
     }

--- a/src/counter/local_counter_primitive.rs
+++ b/src/counter/local_counter_primitive.rs
@@ -1,0 +1,47 @@
+// Copyright 2014 The Prometheus Authors
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use errors::{Result, Error};
+use super::*;
+
+#[derive(Clone, Debug)]
+pub struct LocalCounterPrimitive {
+    val: f64,
+}
+
+impl LocalCounterPrimitive {
+    pub fn new() -> LocalCounterPrimitive {
+        LocalCounterPrimitive {
+            val: 0.0,
+        }
+    }
+}
+
+impl ICounter for LocalCounterPrimitive {
+    fn try_inc_by(&mut self, v: f64) -> Result<()> {
+        if v < 0.0 {
+            return Err(Error::DecreaseCounter(v));
+        }
+        self.val += v;
+        Ok(())
+    }
+
+    fn get(&self) -> f64 {
+        self.val
+    }
+
+    fn reset(&mut self) {
+        self.val = 0.0;
+    }
+}

--- a/src/counter/mod.rs
+++ b/src/counter/mod.rs
@@ -43,7 +43,8 @@ pub trait ICounter {
     /// Reset any temporal value this counter is storing, if applicable.
     fn reset(&mut self);
 
-    /// Merge current counter value into another compatible counter.
+    /// Merge current counter value into another compatible counter. Current counter
+    /// value is not changed after merging.
     #[inline]
     fn merge_to<T: ICounter>(&self, another: &mut T) {
         another.inc_by(self.get());

--- a/src/counter/mod.rs
+++ b/src/counter/mod.rs
@@ -1,0 +1,53 @@
+// Copyright 2014 The Prometheus Authors
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod counter;
+mod local_counter_primitive;
+mod local_counter;
+
+use errors::{Error, Result};
+
+pub use self::counter::Counter;
+pub use self::local_counter_primitive::LocalCounterPrimitive;
+
+pub trait ICounter {
+    /// `try_inc_by` increments the given value to the counter. Error if the value is < 0.
+    #[inline]
+    fn try_inc_by(&mut self, v: f64) -> Result<()>;
+
+    /// `inc_by` increments the given value to the counter. Panics if the value is < 0.
+    #[inline]
+    fn inc_by(&mut self, v: f64) {
+        self.try_inc_by(v).unwrap();
+    }
+
+    /// `inc` increments the counter by 1.
+    #[inline]
+    fn inc(&mut self) {
+        self.inc_by(1.0);
+    }
+
+    /// `get` returns the counter value.
+    #[inline]
+    fn get(&self) -> f64;
+
+    /// Reset any temporal value this counter is storing, if applicable.
+    fn reset(&mut self);
+
+    /// Merge current counter value into another compatible counter and clear current value.
+    fn flush_to<T: ICounter>(&mut self, another: &mut T) {
+        another.inc_by(self.get());
+        self.reset();
+    }
+}

--- a/src/counter/mod.rs
+++ b/src/counter/mod.rs
@@ -23,7 +23,6 @@ pub use self::local_counter_primitive::LocalCounterPrimitive;
 
 pub trait ICounter {
     /// `try_inc_by` increments the given value to the counter. Error if the value is < 0.
-    #[inline]
     fn try_inc_by(&mut self, v: f64) -> Result<()>;
 
     /// `inc_by` increments the given value to the counter. Panics if the value is < 0.
@@ -39,15 +38,21 @@ pub trait ICounter {
     }
 
     /// `get` returns the counter value.
-    #[inline]
     fn get(&self) -> f64;
 
     /// Reset any temporal value this counter is storing, if applicable.
     fn reset(&mut self);
 
-    /// Merge current counter value into another compatible counter and clear current value.
-    fn flush_to<T: ICounter>(&mut self, another: &mut T) {
+    /// Merge current counter value into another compatible counter.
+    #[inline]
+    fn merge_to<T: ICounter>(&self, another: &mut T) {
         another.inc_by(self.get());
+    }
+
+    /// Merge current counter value into another compatible counter and clear current value.
+    #[inline]
+    fn flush_to<T: ICounter>(&mut self, another: &mut T) {
+        self.merge_to(another);
         self.reset();
     }
 }


### PR DESCRIPTION
WIP. Changes:

- [ ] WIP: Rearrange counter into multiple files to keep it clean.
- [x] Introduce `LocalCounterPrimitive`, which is some kind of a `LocalCounter` but not attached to any existing `Counter`. TiKV [self-implemented similar modules](https://github.com/pingcap/tikv/blob/master/src/coprocessor/local_metrics.rs#L36), which is a duplication. I think this library can provide such primitives so that we don't need to implement it again in TiKV.
- [x] Introduce `ICounter` trait (interface), to make `Counter`, `LocalCounter`, `LocalCounterPrimitive` compatible with each other (i.e. can be merged into another).
- [x] `inc_by` -> `try_inc_by` (#151)
- [ ] WIP: `LocalCounterVecPrimitive`.
- [ ] WIP: Eliminate locks in `LocalCouter` (question: do we really need `remove_label_values` in `LocalCounter`?)
- [ ] More to come.

Similar refinements will be applied to Histogram as well, later.