### PR TITLE
counter: private LocalCounter::new

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.3.11"
+version = "0.3.12"
 license = "Apache-2.0"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com"]

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -131,7 +131,7 @@ pub struct LocalCounter {
 
 // LocalCounter is a thread local copy of Counter
 impl LocalCounter {
-    pub fn new(counter: Counter) -> LocalCounter {
+    fn new(counter: Counter) -> LocalCounter {
         LocalCounter {
             counter: counter,
             val: 0.0,


### PR DESCRIPTION
`LocalCounter` should not export `new`, it can only be derived from a `Counter`.