### PR TITLE
registry: do not gather emptied MetricFamily

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.3.12"
+version = "0.3.13"
 license = "Apache-2.0"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com"]


### PR DESCRIPTION
Gather should prune emptied MetricFamily.

```
// normalizeMetricFamilies returns a MetricFamily slice with empty
// MetricFamilies pruned and the remaining MetricFamilies sorted by name within
// the slice, with the contained Metrics sorted within each MetricFamily.
func normalizeMetricFamilies(metricFamiliesByName map[string]*dto.MetricFamily) []*dto.MetricFamily {
	for _, mf := range metricFamiliesByName {
		sort.Sort(metricSorter(mf.Metric))
	}
	names := make([]string, 0, len(metricFamiliesByName))
	for name, mf := range metricFamiliesByName {
		if len(mf.Metric) > 0 {
			names = append(names, name)
		}
	}
	sort.Strings(names)
	result := make([]*dto.MetricFamily, 0, len(names))
	for _, name := range names {
		result = append(result, metricFamiliesByName[name])
	}
	return result
}
```
https://github.com/prometheus/client_golang/blob/a40133b69fbd73ee655606a9bf5f8b9b9bf758dd/prometheus/registry.go#L459

https://github.com/prometheus/client_golang/blob/a40133b69fbd73ee655606a9bf5f8b9b9bf758dd/prometheus/registry.go#L681-L700

Cc https://github.com/pingcap/rust-prometheus/pull/131#issuecomment-364742409