### PR TITLE
Provide try_inc_by to counters to avoid panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+## 0.4.1
+
+- Add: `(Local)(Int)Counter::try_inc_by()` for users who want to handle counter decrease errors instead of panic (#165).
+
 ## 0.4.0
 
-- Add: Provides `IntCounter`, `IntCounterVec`, `IntGauge`, `IntGaugeVec`, `LocalIntCounter`, `LocalIntCounterVec` for better performance when metric values are all integers (#158).
+- Add: `IntCounter`, `IntCounterVec`, `IntGauge`, `IntGaugeVec`, `LocalIntCounter`, `LocalIntCounterVec` for better performance when metric values are all integers (#158).
 
-- Change: When the given value is < 0, `Counter.inc_by` and `LocalCounter.inc_by` no longer return errors, instead it will panic (#156).
+- Change: When the given value is < 0, `(Local)Counter::inc_by()` no longer return errors, instead it will panic (#156).
 
 - Improve performance (#161).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.4.0"
+version = "0.4.1"
 license = "Apache-2.0"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com", "vistaswx@gmail.com"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,6 +30,10 @@ quick_error!{
             description(msg)
             display("Error: {}", msg)
         }
+        DecreaseCounter {
+            description("counter cannot be decreased")
+            display("counter cannot increase negative values")
+        }
         Io(err: IoError) {
             from()
             cause(err)


### PR DESCRIPTION
Users can choice to avoid panics by calling `try_inc_by()`.