### PR TITLE
Reformat using a more recent version of rustfmt

### DIFF
--- a/examples/example_embed.rs
+++ b/examples/example_embed.rs
@@ -13,9 +13,10 @@
 
 extern crate prometheus;
 
-use prometheus::{Counter, CounterVec, Encoder, Gauge, GaugeVec, Opts, Registry, TextEncoder};
 use std::thread;
 use std::time::Duration;
+
+use prometheus::{Counter, CounterVec, Encoder, Gauge, GaugeVec, Opts, Registry, TextEncoder};
 
 fn main() {
     let r = Registry::new();

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -20,25 +20,20 @@ extern crate prometheus;
 use hyper::header::ContentType;
 use hyper::mime::Mime;
 use hyper::server::{Request, Response, Server};
+
 use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder};
 
 lazy_static! {
-    static ref HTTP_COUNTER: Counter = register_counter!(
-        opts!(
-            "example_http_requests_total",
-            "Total number of HTTP requests made.",
-            labels!{"handler" => "all",}
-        )
-    ).unwrap();
-
-    static ref HTTP_BODY_GAUGE: Gauge = register_gauge!(
-        opts!(
-            "example_http_response_size_bytes",
-            "The HTTP response sizes in bytes.",
-            labels!{"handler" => "all",}
-        )
-    ).unwrap();
-
+    static ref HTTP_COUNTER: Counter = register_counter!(opts!(
+        "example_http_requests_total",
+        "Total number of HTTP requests made.",
+        labels!{"handler" => "all",}
+    )).unwrap();
+    static ref HTTP_BODY_GAUGE: Gauge = register_gauge!(opts!(
+        "example_http_response_size_bytes",
+        "The HTTP response sizes in bytes.",
+        labels!{"handler" => "all",}
+    )).unwrap();
     static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
         "example_http_request_duration_seconds",
         "The HTTP request latencies in seconds.",

--- a/examples/example_int_metrics.rs
+++ b/examples/example_int_metrics.rs
@@ -19,27 +19,12 @@ extern crate prometheus;
 use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
 lazy_static! {
-    static ref A_INT_COUNTER: IntCounter = register_int_counter!(
-        "A_int_counter",
-        "foobar"
-    ).unwrap();
-
-    static ref A_INT_COUNTER_VEC: IntCounterVec = register_int_counter_vec!(
-        "A_int_counter_vec",
-        "foobar",
-        &["a", "b"]
-    ).unwrap();
-
-    static ref A_INT_GAUGE: IntGauge = register_int_gauge!(
-        "A_int_gauge",
-        "foobar"
-    ).unwrap();
-
-    static ref A_INT_GAUGE_VEC: IntGaugeVec = register_int_gauge_vec!(
-        "A_int_gauge_vec",
-        "foobar",
-        &["a", "b"]
-    ).unwrap();
+    static ref A_INT_COUNTER: IntCounter = register_int_counter!("A_int_counter", "foobar").unwrap();
+    static ref A_INT_COUNTER_VEC: IntCounterVec =
+        register_int_counter_vec!("A_int_counter_vec", "foobar", &["a", "b"]).unwrap();
+    static ref A_INT_GAUGE: IntGauge = register_int_gauge!("A_int_gauge", "foobar").unwrap();
+    static ref A_INT_GAUGE_VEC: IntGaugeVec =
+        register_int_gauge_vec!("A_int_gauge_vec", "foobar", &["a", "b"]).unwrap();
 }
 
 fn main() {

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -15,9 +15,10 @@ extern crate prometheus;
 
 #[cfg(all(feature = "process", target_os = "linux"))]
 fn main() {
-    use prometheus::{self, Encoder};
     use std::thread;
     use std::time::Duration;
+
+    use prometheus::{self, Encoder};
 
     // A default ProcessCollector is registered automatically.
     let mut buffer = Vec::new();

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -19,18 +19,18 @@ extern crate lazy_static;
 #[macro_use]
 extern crate prometheus;
 
-use getopts::Options;
-use prometheus::{Counter, Histogram};
 use std::env;
 use std::thread;
 use std::time;
+
+use getopts::Options;
+use prometheus::{Counter, Histogram};
 
 lazy_static! {
     static ref PUSH_COUNTER: Counter = register_counter!(
         "example_push_total",
         "Total number of prometheus client pushed."
     ).unwrap();
-
     static ref PUSH_REQ_HISTOGRAM: Histogram = register_histogram!(
         "example_push_request_duration_seconds",
         "The push request latencies in seconds."

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,5 @@
 reorder_imports = true
+reorder_imports_in_group = true
+reorder_extern_crates = true
+reorder_extern_crates_in_group = true
 use_try_shorthand = true

--- a/src/atomic64/fallback.rs
+++ b/src/atomic64/fallback.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{Atomic, Number};
 use spin::RwLock;
+
+use super::{Atomic, Number};
 
 pub struct RwlockAtomic<T: super::Number> {
     inner: RwLock<T>,

--- a/src/atomic64/mod.rs
+++ b/src/atomic64/mod.rs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::*;
+use std::ops::*;
+
 #[cfg(not(feature = "nightly"))]
 mod fallback;
 #[cfg(not(feature = "nightly"))]
@@ -21,14 +24,12 @@ pub use self::fallback::{AtomicF64, AtomicI64, AtomicU64};
 mod nightly;
 #[cfg(feature = "nightly")]
 pub use self::nightly::{AtomicF64, AtomicI64, AtomicU64};
-use std::cmp::*;
-use std::ops::*;
 
 /// An interface for numbers. Used to generically model float metrics and integer metrics, i.e.
 /// [`Counter`](::Counter) and [`IntCounter`](::IntCounter).
-pub trait Number
-    : Sized + AddAssign + SubAssign + PartialOrd + PartialEq + Copy + Send + Sync
-    {
+pub trait Number:
+    Sized + AddAssign + SubAssign + PartialOrd + PartialEq + Copy + Send + Sync
+{
     /// `std::convert::From<i64> for f64` is not implemented, so that we need to implement our own.
     fn from_i64(v: i64) -> Self;
 
@@ -85,8 +86,8 @@ pub trait Atomic: Send + Sync {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::f64::{self, EPSILON};
     use std::f64::consts::PI;
+    use std::f64::{self, EPSILON};
 
     #[test]
     fn test_atomic_f64() {

--- a/src/atomic64/nightly.rs
+++ b/src/atomic64/nightly.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::Atomic;
 use std::f64;
 use std::sync::atomic::{AtomicI64 as StdAtomicI64, AtomicU64 as StdAtomicU64, Ordering};
+
+use super::Atomic;
 
 pub struct AtomicF64 {
     inner: StdAtomicU64,

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
 use atomic64::{Atomic, AtomicF64, AtomicI64, Number};
 use desc::Desc;
 use errors::Result;
 use metrics::{Collector, Metric, Opts};
 use proto;
-use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::sync::Arc;
 use value::{Value, ValueType};
 use vec::{MetricVec, MetricVecBuilder};
 

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use errors::{Error, Result};
-use fnv::FnvHasher;
-use metrics::SEPARATOR_BYTE;
-use proto::LabelPair;
 use std::collections::{BTreeSet, HashMap};
 use std::hash::Hasher;
+
+use fnv::FnvHasher;
+
+use errors::{Error, Result};
+use metrics::SEPARATOR_BYTE;
+use proto::LabelPair;
 
 // TODO: use `char::is_ascii` instead once it landed in the stable rust.
 // Refer to https://github.com/rust-lang/rust/blob/
@@ -112,9 +114,9 @@ impl Desc {
     ) -> Result<Desc> {
         let mut desc = Desc {
             fq_name: fq_name.clone(),
-            help: help,
+            help,
             const_label_pairs: Vec::with_capacity(const_labels.len()),
-            variable_labels: variable_labels,
+            variable_labels,
             id: 0,
             dim_hash: 0,
         };

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -11,12 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use errors::{Error, Result};
-use proto::MetricFamily;
 use std::io::Write;
 
-mod text;
+use errors::{Error, Result};
+use proto::MetricFamily;
+
 mod pb;
+mod text;
 
 pub use self::pb::{ProtobufEncoder, PROTOBUF_FORMAT};
 pub use self::text::{TextEncoder, TEXT_FORMAT};

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -11,11 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{check_metric_family, Encoder};
+use std::io::Write;
+
 use errors::Result;
 use proto::MetricFamily;
 use protobuf::Message;
-use std::io::Write;
+
+use super::{check_metric_family, Encoder};
 
 /// The protocol buffer format of metric family.
 pub const PROTOBUF_FORMAT: &str = "application/vnd.google.protobuf; \

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -11,12 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{check_metric_family, Encoder};
+use std::io::Write;
+
 use errors::Result;
 use histogram::BUCKET_LABEL;
-use proto::{self, MetricType};
 use proto::MetricFamily;
-use std::io::Write;
+use proto::{self, MetricType};
+
+use super::{check_metric_family, Encoder};
 
 /// The text format of metric family.
 pub const TEXT_FORMAT: &str = "text/plain; version=0.0.4";

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,9 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use protobuf::error::ProtobufError;
 use std::io::Error as IoError;
 use std::result;
+
+use protobuf::error::ProtobufError;
 
 quick_error!{
     /// The error types for prometheus.

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -12,13 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::marker::PhantomData;
+use std::sync::Arc;
+
 use atomic64::{Atomic, AtomicF64, AtomicI64, Number};
 use desc::Desc;
 use errors::Result;
 use metrics::{Collector, Metric, Opts};
 use proto;
-use std::marker::PhantomData;
-use std::sync::Arc;
 use value::{Value, ValueType};
 use vec::{MetricVec, MetricVecBuilder};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ The Rust client library for [Prometheus](https://prometheus.io/).
 #![cfg_attr(feature = "dev", plugin(clippy))]
 #![cfg_attr(not(feature = "dev"), allow(unknown_lints))]
 #![cfg_attr(feature = "dev", allow(needless_pass_by_value))]
+#![cfg_attr(feature = "dev", allow(new_without_default_derive))]
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
 
 #[macro_use]
@@ -40,27 +41,27 @@ extern crate spin;
 #[cfg(all(test, bench))]
 extern crate test;
 
-mod errors;
 mod encoder;
+mod errors;
 #[macro_use]
 mod macros;
-mod metrics;
-mod desc;
-mod value;
+mod atomic64;
 mod counter;
+mod desc;
 mod gauge;
-mod registry;
-mod vec;
 mod histogram;
+mod metrics;
 #[cfg(feature = "push")]
 mod push;
-mod atomic64;
+mod registry;
+mod value;
+mod vec;
 
-/// Protocol buffers format of metrics.
-#[path="../proto/metrics.rs"]
-pub mod proto;
 #[cfg(all(feature = "process", target_os = "linux"))]
 pub mod process_collector;
+/// Protocol buffers format of metrics.
+#[path = "../proto/metrics.rs"]
+pub mod proto;
 
 pub mod local {
     /*!
@@ -92,17 +93,17 @@ pub mod core {
 }
 
 pub use self::counter::{Counter, CounterVec, IntCounter, IntCounterVec};
+pub use self::encoder::Encoder;
 pub use self::encoder::{PROTOBUF_FORMAT, TEXT_FORMAT};
 pub use self::encoder::{ProtobufEncoder, TextEncoder};
-pub use self::encoder::Encoder;
 pub use self::errors::{Error, Result};
 pub use self::gauge::{Gauge, GaugeVec, IntGauge, IntGaugeVec};
+pub use self::histogram::DEFAULT_BUCKETS;
 pub use self::histogram::{Histogram, HistogramOpts, HistogramTimer, HistogramVec};
 pub use self::histogram::{exponential_buckets, linear_buckets};
-pub use self::histogram::DEFAULT_BUCKETS;
 pub use self::metrics::Opts;
 #[cfg(feature = "push")]
 pub use self::push::{hostname_grouping_key, push_add_collector, push_add_metrics, push_collector,
                      push_metrics};
-pub use self::registry::{gather, register, unregister};
 pub use self::registry::Registry;
+pub use self::registry::{gather, register, unregister};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -134,36 +134,28 @@ macro_rules! opts {
 /// ```
 #[macro_export]
 macro_rules! histogram_opts {
-    ( $ NAME : expr , $ HELP : expr ) => {
-        {
-            $crate::HistogramOpts::new($NAME, $HELP)
-        }
-    };
+    ($NAME:expr, $HELP:expr) => {{
+        $crate::HistogramOpts::new($NAME, $HELP)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr ) => {
-        {
-            let hopts = histogram_opts!($NAME, $HELP);
-            hopts.buckets($BUCKETS)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $BUCKETS:expr) => {{
+        let hopts = histogram_opts!($NAME, $HELP);
+        hopts.buckets($BUCKETS)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr , $ CONST_LABELS : expr ) => {
-        {
-            let hopts = histogram_opts!($NAME, $HELP, $BUCKETS);
-            hopts.const_labels($CONST_LABELS)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $BUCKETS:expr, $CONST_LABELS:expr) => {{
+        let hopts = histogram_opts!($NAME, $HELP, $BUCKETS);
+        hopts.const_labels($CONST_LABELS)
+    }};
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __register_counter {
-    ( $ TYPE : ident, $ OPTS : expr ) => {
-        {
-            let counter = $crate::$TYPE::with_opts($OPTS).unwrap();
-            $crate::register(Box::new(counter.clone())).map(|_| counter)
-        }
-    };
+    ($TYPE:ident, $OPTS:expr) => {{
+        let counter = $crate::$TYPE::with_opts($OPTS).unwrap();
+        $crate::register(Box::new(counter.clone())).map(|_| counter)
+    }};
 }
 
 /// Create a [`Counter`](::Counter) and registerss to default registry.
@@ -183,17 +175,13 @@ macro_rules! __register_counter {
 /// ```
 #[macro_export]
 macro_rules! register_counter {
-    ( $ OPTS : expr ) => {
-        {
-            __register_counter!(Counter, $OPTS)
-        }
-    };
+    ($OPTS:expr) => {{
+        __register_counter!(Counter, $OPTS)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr ) => {
-        {
-            register_counter!(opts!($NAME, $HELP))
-        }
-    };
+    ($NAME:expr, $HELP:expr) => {{
+        register_counter!(opts!($NAME, $HELP))
+    }};
 }
 
 /// Create an [`IntCounter`](::IntCounter) and registers to default registry.
@@ -201,28 +189,22 @@ macro_rules! register_counter {
 /// View docs of `register_counter` for examples.
 #[macro_export]
 macro_rules! register_int_counter {
-    ( $ OPTS : expr ) => {
-        {
-            __register_counter!(IntCounter, $OPTS)
-        }
-    };
+    ($OPTS:expr) => {{
+        __register_counter!(IntCounter, $OPTS)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr ) => {
-        {
-            register_int_counter!(opts!($NAME, $HELP))
-        }
-    };
+    ($NAME:expr, $HELP:expr) => {{
+        register_int_counter!(opts!($NAME, $HELP))
+    }};
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __register_counter_vec {
-    ( $ TYPE : ident , $ OPTS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            let counter_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
-            $crate::register(Box::new(counter_vec.clone())).map(|_| counter_vec)
-        }
-    };
+    ($TYPE:ident, $OPTS:expr, $LABELS_NAMES:expr) => {{
+        let counter_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
+        $crate::register(Box::new(counter_vec.clone())).map(|_| counter_vec)
+    }};
 }
 
 /// Create a [`CounterVec`](::CounterVec) and registers to default registry.
@@ -242,17 +224,13 @@ macro_rules! __register_counter_vec {
 /// ```
 #[macro_export]
 macro_rules! register_counter_vec {
-    ( $ OPTS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            __register_counter_vec!(CounterVec, $OPTS, $LABELS_NAMES)
-        }
-    };
+    ($OPTS:expr, $LABELS_NAMES:expr) => {{
+        __register_counter_vec!(CounterVec, $OPTS, $LABELS_NAMES)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr ) => {
-        {
-            register_counter_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr) => {{
+        register_counter_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
+    }};
 }
 
 /// Create an [`IntCounterVec`](::IntCounterVec) and registers to default registry.
@@ -260,28 +238,22 @@ macro_rules! register_counter_vec {
 /// View docs of `register_counter_vec` for examples.
 #[macro_export]
 macro_rules! register_int_counter_vec {
-    ( $ OPTS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            __register_counter_vec!(IntCounterVec, $OPTS, $LABELS_NAMES)
-        }
-    };
+    ($OPTS:expr, $LABELS_NAMES:expr) => {{
+        __register_counter_vec!(IntCounterVec, $OPTS, $LABELS_NAMES)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr ) => {
-        {
-            register_int_counter_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr) => {{
+        register_int_counter_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
+    }};
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __register_gauge {
-    ( $ TYPE : ident , $ OPTS : expr ) => {
-        {
-            let gauge = $crate::$TYPE::with_opts($OPTS).unwrap();
-            $crate::register(Box::new(gauge.clone())).map(|_| gauge)
-        }
-    };
+    ($TYPE:ident, $OPTS:expr) => {{
+        let gauge = $crate::$TYPE::with_opts($OPTS).unwrap();
+        $crate::register(Box::new(gauge.clone())).map(|_| gauge)
+    }};
 }
 
 /// Create a [`Gauge`](::Gauge) and registers to default registry.
@@ -301,17 +273,13 @@ macro_rules! __register_gauge {
 /// ```
 #[macro_export]
 macro_rules! register_gauge {
-    ( $ OPTS : expr ) => {
-        {
-            __register_gauge!(Gauge, $OPTS)
-        }
-    };
+    ($OPTS:expr) => {{
+        __register_gauge!(Gauge, $OPTS)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr ) => {
-        {
-            register_gauge!(opts!($NAME, $HELP))
-        }
-    };
+    ($NAME:expr, $HELP:expr) => {{
+        register_gauge!(opts!($NAME, $HELP))
+    }};
 }
 
 /// Create an [`IntGauge`](::IntGauge) and registers to default registry.
@@ -319,28 +287,22 @@ macro_rules! register_gauge {
 /// View docs of `register_gauge` for examples.
 #[macro_export]
 macro_rules! register_int_gauge {
-    ( $ OPTS : expr ) => {
-        {
-            __register_gauge!(IntGauge, $OPTS)
-        }
-    };
+    ($OPTS:expr) => {{
+        __register_gauge!(IntGauge, $OPTS)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr ) => {
-        {
-            register_int_gauge!(opts!($NAME, $HELP))
-        }
-    };
+    ($NAME:expr, $HELP:expr) => {{
+        register_int_gauge!(opts!($NAME, $HELP))
+    }};
 }
 
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __register_gauge_vec {
-    ( $ TYPE : ident , $ OPTS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            let gauge_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
-            $crate::register(Box::new(gauge_vec.clone())).map(|_| gauge_vec)
-        }
-    };
+    ($TYPE:ident, $OPTS:expr, $LABELS_NAMES:expr) => {{
+        let gauge_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
+        $crate::register(Box::new(gauge_vec.clone())).map(|_| gauge_vec)
+    }};
 }
 
 /// Create a [`GaugeVec`](::GaugeVec) and registers to default registry.
@@ -360,17 +322,13 @@ macro_rules! __register_gauge_vec {
 /// ```
 #[macro_export]
 macro_rules! register_gauge_vec {
-    ( $ OPTS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            __register_gauge_vec!(GaugeVec, $OPTS, $LABELS_NAMES)
-        }
-    };
+    ($OPTS:expr, $LABELS_NAMES:expr) => {{
+        __register_gauge_vec!(GaugeVec, $OPTS, $LABELS_NAMES)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr ) => {
-        {
-            register_gauge_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr) => {{
+        register_gauge_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
+    }};
 }
 
 /// Create an [`IntGaugeVec`](::IntGaugeVec) and registers to default registry.
@@ -378,17 +336,13 @@ macro_rules! register_gauge_vec {
 /// View docs of `register_gauge_vec` for examples.
 #[macro_export]
 macro_rules! register_int_gauge_vec {
-    ( $ OPTS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            __register_gauge_vec!(IntGaugeVec, $OPTS, $LABELS_NAMES)
-        }
-    };
+    ($OPTS:expr, $LABELS_NAMES:expr) => {{
+        __register_gauge_vec!(IntGaugeVec, $OPTS, $LABELS_NAMES)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr ) => {
-        {
-            register_int_gauge_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr) => {{
+        register_int_gauge_vec!(opts!($NAME, $HELP), $LABELS_NAMES)
+    }};
 }
 
 /// Create a [`Histogram`](::Histogram) and registers to default registry.
@@ -413,20 +367,18 @@ macro_rules! register_int_gauge_vec {
 /// ```
 #[macro_export]
 macro_rules! register_histogram {
-    ( $ NAME : expr , $ HELP : expr ) => {
+    ($NAME:expr, $HELP:expr) => {
         register_histogram!(histogram_opts!($NAME, $HELP))
     };
 
-    ( $ NAME : expr , $ HELP : expr , $ BUCKETS : expr ) => {
+    ($NAME:expr, $HELP:expr, $BUCKETS:expr) => {
         register_histogram!(histogram_opts!($NAME, $HELP, $BUCKETS))
     };
 
-    ( $ HOPTS : expr ) => {
-        {
-            let histogram = $crate::Histogram::with_opts($HOPTS).unwrap();
-            $crate::register(Box::new(histogram.clone())).map(|_| histogram)
-        }
-    }
+    ($HOPTS:expr) => {{
+        let histogram = $crate::Histogram::with_opts($HOPTS).unwrap();
+        $crate::register(Box::new(histogram.clone())).map(|_| histogram)
+    }};
 }
 
 /// Create a [`HistogramVec`](::HistogramVec) and registers to default registry.
@@ -453,22 +405,16 @@ macro_rules! register_histogram {
 /// ```
 #[macro_export]
 macro_rules! register_histogram_vec {
-    ( $ HOPTS : expr , $ LABELS_NAMES : expr ) => {
-        {
-            let histogram_vec = $crate::HistogramVec::new($HOPTS, $LABELS_NAMES).unwrap();
-            $crate::register(Box::new(histogram_vec.clone())).map(|_| histogram_vec)
-        }
-    };
+    ($HOPTS:expr, $LABELS_NAMES:expr) => {{
+        let histogram_vec = $crate::HistogramVec::new($HOPTS, $LABELS_NAMES).unwrap();
+        $crate::register(Box::new(histogram_vec.clone())).map(|_| histogram_vec)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr ) => {
-        {
-            register_histogram_vec!(histogram_opts!($NAME, $HELP), $LABELS_NAMES)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr) => {{
+        register_histogram_vec!(histogram_opts!($NAME, $HELP), $LABELS_NAMES)
+    }};
 
-    ( $ NAME : expr , $ HELP : expr , $ LABELS_NAMES : expr , $ BUCKETS : expr) => {
-        {
-            register_histogram_vec!(histogram_opts!($NAME, $HELP, $BUCKETS), $LABELS_NAMES)
-        }
-    };
+    ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr, $BUCKETS:expr) => {{
+        register_histogram_vec!(histogram_opts!($NAME, $HELP, $BUCKETS), $LABELS_NAMES)
+    }};
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp::{Eq, Ord, Ordering, PartialOrd};
+use std::collections::HashMap;
+
 use desc::{Desc, Describer};
 use errors::Result;
 use proto::{self, LabelPair};
-use std::cmp::{Eq, Ord, Ordering, PartialOrd};
-use std::collections::HashMap;
 
 pub const SEPARATOR_BYTE: u8 = 0xFF;
 

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -15,19 +15,22 @@
 //!
 //! This module only supports **Linux** platform.
 
+use std::fs;
+use std::io::Read;
+use std::sync::Mutex;
+
+use libc;
+use procinfo::pid as pid_info;
+
 use counter::Counter;
 use desc::Desc;
 use errors::{Error, Result};
 use gauge::Gauge;
-use libc;
+use metrics::{Collector, Opts};
+use proto;
+
 /// The `pid_t` data type represents process IDs.
 pub use libc::pid_t;
-use metrics::{Collector, Opts};
-use procinfo::pid as pid_info;
-use proto;
-use std::fs;
-use std::io::Read;
-use std::sync::Mutex;
 
 // Six metrics per ProcessCollector.
 const MERTICS_NUMBER: usize = 6;
@@ -247,9 +250,9 @@ lazy_static! {
     static ref BOOT_TIME: Option<f64> = {
         let mut buffer = String::new();
         fs::File::open("/proc/stat")
-            .and_then(|mut f| f.read_to_string(&mut buffer)).ok().and_then(|_| {
-               find_statistic(&buffer, BOOT_TIME_PATTERN).ok()
-            })
+            .and_then(|mut f| f.read_to_string(&mut buffer))
+            .ok()
+            .and_then(|_| find_statistic(&buffer, BOOT_TIME_PATTERN).ok())
     };
 }
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -12,35 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use encoder::{Encoder, ProtobufEncoder};
-use errors::{Error, Result};
-use hyper::client::Client;
-use hyper::client::pool::Config;
-use hyper::header::ContentType;
-use hyper::method::Method;
-use hyper::status::StatusCode;
-use metrics::Collector;
-use proto;
-use registry::Registry;
 use std::collections::HashMap;
 use std::hash::BuildHasher;
 use std::str::{self, FromStr};
 use std::time::Duration;
 
+use hyper::client::Client;
+use hyper::client::pool::Config;
+use hyper::header::ContentType;
+use hyper::method::Method;
+use hyper::status::StatusCode;
+
+use encoder::{Encoder, ProtobufEncoder};
+use errors::{Error, Result};
+use metrics::Collector;
+use proto;
+use registry::Registry;
+
 const HYPER_MAX_IDLE: usize = 1;
 const HYPER_TIMEOUT_SEC: u64 = 10;
 
-lazy_static!{
+lazy_static! {
     static ref HTTP_CLIENT: Client = {
-            let mut client = Client::with_pool_config(
-                Config{
-                    max_idle: HYPER_MAX_IDLE,
-                }
-            );
-            client.set_read_timeout(Some(Duration::from_secs(HYPER_TIMEOUT_SEC)));
-            client.set_write_timeout(Some(Duration::from_secs(HYPER_TIMEOUT_SEC)));
-            client
-        };
+        let mut client = Client::with_pool_config(Config {
+            max_idle: HYPER_MAX_IDLE,
+        });
+        client.set_read_timeout(Some(Duration::from_secs(HYPER_TIMEOUT_SEC)));
+        client.set_write_timeout(Some(Duration::from_secs(HYPER_TIMEOUT_SEC)));
+        client
+    };
 }
 
 /// `push_metrics` pushes all gathered metrics to the Pushgateway specified by

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -12,15 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::btree_map::Entry as BEntry;
+use std::collections::hash_map::Entry as HEntry;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::iter::FromIterator;
+use std::sync::Arc;
+
+use spin::RwLock;
+
 use errors::{Error, Result};
 use metrics::Collector;
 use proto;
-use spin::RwLock;
-use std::collections::{BTreeMap, HashMap, HashSet};
-use std::collections::btree_map::Entry as BEntry;
-use std::collections::hash_map::Entry as HEntry;
-use std::iter::FromIterator;
-use std::sync::Arc;
 
 struct RegistryCore {
     pub colloctors_by_id: HashMap<u64, Box<Collector>>,
@@ -445,10 +447,7 @@ mod tests {
             },
         );
 
-        let mc = MultipleCollector {
-            descs: descs,
-            counters: counters,
-        };
+        let mc = MultipleCollector { descs, counters };
 
         let r = Registry::new();
         r.register(Box::new(mc)).unwrap();

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use protobuf::RepeatedField;
+
 use atomic64::{Atomic, Number};
 use desc::{Desc, Describer};
 use errors::{Error, Result};
 use proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
-use protobuf::RepeatedField;
 
 /// `ValueType` is an enumeration of metric types that represent a simple value
 /// for [`Counter`](::Counter) and [`Gauge`](::Gauge).
@@ -49,7 +50,7 @@ pub struct Value<P: Atomic> {
 impl<P: Atomic> Value<P> {
     pub fn new<D: Describer>(
         describer: &D,
-        value_type: ValueType,
+        val_type: ValueType,
         val: P::T,
         label_values: &[&str],
     ) -> Result<Self> {
@@ -64,10 +65,10 @@ impl<P: Atomic> Value<P> {
         let label_pairs = make_label_pairs(&desc, label_values);
 
         Ok(Self {
-            desc: desc,
+            desc,
             val: P::new(val),
-            val_type: value_type,
-            label_pairs: label_pairs,
+            val_type,
+            label_pairs,
         })
     }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -12,16 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use desc::{Desc, Describer};
-use errors::{Error, Result};
-use fnv::FnvHasher;
-use metrics::{Collector, Metric};
-use proto::{MetricFamily, MetricType};
-use protobuf::RepeatedField;
-use spin::RwLock;
 use std::collections::HashMap;
 use std::hash::Hasher;
 use std::sync::Arc;
+
+use fnv::FnvHasher;
+use protobuf::RepeatedField;
+use spin::RwLock;
+
+use desc::{Desc, Describer};
+use errors::{Error, Result};
+use metrics::{Collector, Metric};
+use proto::{MetricFamily, MetricType};
 
 /// An interface for building a metric vector.
 pub trait MetricVecBuilder: Send + Sync + Clone {
@@ -190,10 +192,10 @@ impl<T: MetricVecBuilder> MetricVec<T> {
         let desc = opts.describe()?;
         let v = MetricVecCore {
             children: RwLock::new(HashMap::new()),
-            desc: desc,
-            metric_type: metric_type,
-            new_metric: new_metric,
-            opts: opts,
+            desc,
+            metric_type,
+            new_metric,
+            opts,
         };
 
         Ok(MetricVec { v: Arc::new(v) })


### PR DESCRIPTION
Pinning rustfmt to the version that TiKV is using currently.

Also re-arranged `use` statements to be grouped follows this order:

1. std
2. 3rd-party modules
3. super or internal modules
