### PR TITLE
Bump versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.2
 
-- Change: Update protobuf dependency.
+- Change: Update to use protobuf 2.0.
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.2
+
+- Change: Update protobuf dependency.
+
 ## 0.4.1
 
 - Change: `(Local)(Int)Counter.inc_by` only panics in debug build if the given value is < 0 (#168).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.4.1"
+version = "0.4.2"
 license = "Apache-2.0"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com", "vistaswx@gmail.com"]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ println!("{}", String::from_utf8(buffer).unwrap());
 
 [More Examples](./examples)
 
+## Advanced
+
+### Static Metric
+
+Static metric helps you make metric vectors faster.
+
+See [static-metric](./static-metric) directory for details.
+
 ## Thanks
 
 + [brian-brazil](https://github.com/brian-brazil)

--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-static-metric"
-version = "0.1.1"
+version = "0.1.2"
 license = "Apache-2.0"
 authors = ["me@breeswish.org"]
 description = "Static metric helper utilities for rust-prometheus."
@@ -23,7 +23,7 @@ quote = "0.5"
 lazy_static = "1.0"
 
 [dev-dependencies]
-prometheus = "0.4"
+prometheus = "^0"
 
 [features]
 default = []


### PR DESCRIPTION
We have introduced some changes recently, for example, updating the protobuf version. This PR bumps the version for publishing.
