### PR TITLE
Make compile-time-unknown static metrics type safe

### DIFF
--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus-static-metric"
-version = "0.1.2"
+version = "0.1.3"
 license = "Apache-2.0"
 authors = ["me@breeswish.org"]
 description = "Static metric helper utilities for rust-prometheus."

--- a/static-metric/examples/advanced.rs
+++ b/static-metric/examples/advanced.rs
@@ -70,9 +70,9 @@ fn main() {
     // Note: You cannot specify values other than the definition in `get()` because
     // it is purely static.
     HTTP_COUNTER
-        .get("delete")
+        .try_get("delete")
         .unwrap()
-        .get("HTTP/1")
+        .try_get("HTTP/1")
         .unwrap()
         .foo
         .inc_by(7);

--- a/static-metric/examples/metric_enum.rs
+++ b/static-metric/examples/metric_enum.rs
@@ -26,14 +26,14 @@ use prometheus::{CounterVec, IntCounterVec, Opts};
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {
-    label_enum Methods {
+    pub label_enum Methods {
         post,
         get,
         put,
         delete,
     }
 
-    label_enum Products {
+    pub label_enum Products {
         foo,
         bar,
     }
@@ -61,6 +61,10 @@ fn main() {
     assert_eq!(static_counter_vec.post.bar.get(), 0.0);
     assert_eq!(vec.with_label_values(&["post", "foo"]).get(), 1.0);
     assert_eq!(vec.with_label_values(&["delete", "bar"]).get(), 4.0);
+
+    // metric enums will expose an enum for type-safe `get()`.
+    static_counter_vec.get(Methods::post).foo.inc();
+    assert_eq!(static_counter_vec.post.foo.get(), 2.0);
 
     let vec = IntCounterVec::new(Opts::new("foo", "bar"), &["error", "error_method"]).unwrap();
     let static_counter_vec = MyAnotherStaticCounterVec::from(&vec);

--- a/static-metric/src/builder.rs
+++ b/static-metric/src/builder.rs
@@ -126,11 +126,31 @@ impl TokensBuilder {
         let visibility = &label_enum.visibility;
         let enum_name = &label_enum.enum_name;
         let enum_item_names = label_enum.definitions.get_names();
+        let enum_item_values = label_enum.definitions.get_values();
+        let match_patterns = label_enum.build_fields_with_path();
+
         quote!{
             #[allow(dead_code)]
             #[allow(non_camel_case_types)]
+            #[derive(Clone, Copy, PartialEq)]
             #visibility enum #enum_name {
                 #(#enum_item_names),*
+            }
+
+            impl ::std::fmt::Debug for #enum_name {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    match self {
+                        #(
+                            #match_patterns => write!(f, #enum_item_values),
+                        )*
+                    }
+                }
+            }
+
+            impl ::std::fmt::Display for #enum_name {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                    ::std::fmt::Debug::fmt(self, f)
+                }
             }
         }
     }

--- a/static-metric/src/builder.rs
+++ b/static-metric/src/builder.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use quote::Tokens;
-use syn::Ident;
+use syn::{Ident, Visibility};
 
 use super::parser::*;
 use super::util;
@@ -35,11 +35,13 @@ impl TokensBuilder {
         for item in macro_body.items.into_iter() {
             match item {
                 StaticMetricMacroBodyItem::Metric(m) => {
-                    // If this is a metric definition, append tokens.
-                    tokens.append_all(Self::build_static_metric(&m, &enums_definitions));
+                    // If this is a metric definition, expand to a `struct`.
+                    tokens.append_all(Self::build_metric_struct(&m, &enums_definitions));
                 }
                 StaticMetricMacroBodyItem::Enum(e) => {
-                    // If this is an enum definition, add to the collection.
+                    // If this is a label enum definition, expand to an `enum` and
+                    // add to the collection.
+                    tokens.append_all(Self::build_label_enum(&e));
                     enums_definitions.insert(e.enum_name.clone(), e);
                 }
             }
@@ -47,10 +49,37 @@ impl TokensBuilder {
         tokens
     }
 
-    fn build_static_metric(
+    fn build_metric_struct(
         metric: &MetricDef,
         enum_definitions: &HashMap<Ident, MetricEnumDef>,
     ) -> Tokens {
+        // Check `label_enum` references.
+        for label in &metric.labels {
+            let enum_ident = label.get_enum_ident();
+            if let Some(e) = enum_ident {
+                // If metric is using a `label_enum`, it must exist before the metric definition.
+                let enum_def = enum_definitions.get(e);
+                if enum_def.is_none() {
+                    panic!("Label enum `{}` is undefined.", e)
+                }
+
+                // If metric has `pub` visibility, then `label_enum` should also be `pub`.
+                // TODO: Support other visibility, like `pub(xx)`.
+                if let Visibility::Public(_) = metric.visibility {
+                    if let Visibility::Public(_) = enum_def.unwrap().visibility {
+                        // `pub` is ok.
+                    } else {
+                        // others are unexpected.
+                        panic!(
+                            "Label enum `{}` does not have enough visibility because it is \
+                             used in metric `{}` which has `pub` visibility.",
+                            e, metric.struct_name
+                        );
+                    }
+                }
+            }
+        }
+
         let label_struct: Vec<_> = metric
             .labels
             .iter()
@@ -89,6 +118,19 @@ impl TokensBuilder {
                 #(
                     #label_struct
                 )*
+            }
+        }
+    }
+
+    fn build_label_enum(label_enum: &MetricEnumDef) -> Tokens {
+        let visibility = &label_enum.visibility;
+        let enum_name = &label_enum.enum_name;
+        let enum_values = label_enum.get_values().iter().map(|value| value.name);
+        quote!{
+            #[allow(dead_code)]
+            #[allow(non_camel_case_types)]
+            #visibility enum #enum_name {
+                #(#enum_values),*
             }
         }
     }
@@ -154,11 +196,13 @@ impl<'a> MetricBuilderContext<'a> {
     fn build_impl(&self) -> Tokens {
         let struct_name = &self.struct_name;
         let impl_from = self.build_impl_from();
-        let impl_get_by_label = self.build_impl_get();
+        let impl_get = self.build_impl_get();
+        let impl_try_get = self.build_impl_try_get();
         quote!{
             impl #struct_name {
                 #impl_from
-                #impl_get_by_label
+                #impl_get
+                #impl_try_get
             }
         }
     }
@@ -233,13 +277,41 @@ impl<'a> MetricBuilderContext<'a> {
         }
     }
 
+    /// `fn get()` is only available when label is defined by `label_enum`.
     fn build_impl_get(&self) -> Tokens {
+        let enum_ident = self.label.get_enum_ident();
+        if let Some(ident) = enum_ident {
+            let member_type = &self.member_type;
+            let values = self.label.get_values(self.enum_definitions);
+            let enum_fields: Vec<_> = values
+                .iter()
+                .map(|v| {
+                    let name = &v.name;
+                    quote!{#ident::#name}
+                })
+                .collect();
+            let metric_fields: Vec<_> = values.iter().map(|v| &v.name).collect();
+            quote!{
+                pub fn get(&self, value: #ident) -> &#member_type {
+                    match value {
+                        #(
+                            #enum_fields => &self.#metric_fields,
+                        )*
+                    }
+                }
+            }
+        } else {
+            Tokens::new()
+        }
+    }
+
+    fn build_impl_try_get(&self) -> Tokens {
         let member_type = &self.member_type;
         let values = self.label.get_values(self.enum_definitions);
         let values_str: Vec<_> = values.iter().map(|v| &v.value).collect();
         let names_ident: Vec<_> = values.iter().map(|v| &v.name).collect();
         quote!{
-            pub fn get(&self, value: &str) -> Option<&#member_type> {
+            pub fn try_get(&self, value: &str) -> Option<&#member_type> {
                 match value {
                     #(
                         #values_str => Some(&self.#names_ident),

--- a/static-metric/src/parser.rs
+++ b/static-metric/src/parser.rs
@@ -39,18 +39,18 @@ impl Synom for LabelEnum {
     }
 }
 
-/// Matches `... => { ... name: value_expr ... }`
+/// Matches `... => { ... name: value_string_literal ... }`
 #[derive(Debug)]
 struct MetricValueDefFull {
     name: Ident,
-    value: Expr,
+    value: LitStr,
 }
 
 impl Synom for MetricValueDefFull {
     named!(parse -> Self, do_parse!(
         name: syn!(Ident) >>
         punct!(:) >>
-        value: syn!(Expr) >>
+        value: syn!(LitStr) >>
         (MetricValueDefFull { name, value })
     ));
 }
@@ -68,11 +68,11 @@ impl Synom for MetricValueDefShort {
     ));
 }
 
-/// Matches either `... => { ... name: value_expr ... }` or `... => { ... value ... }`
+/// Matches either `... => { ... name: value_string_literal ... }` or `... => { ... value ... }`
 #[derive(Debug)]
 pub struct MetricValueDef {
     pub name: Ident,
-    pub value: Expr,
+    pub value: LitStr,
 }
 
 impl Synom for MetricValueDef {
@@ -94,13 +94,9 @@ impl From<MetricValueDefFull> for MetricValueDef {
 
 impl From<MetricValueDefShort> for MetricValueDef {
     fn from(e: MetricValueDefShort) -> MetricValueDef {
-        let value_lit = Lit::from(LitStr::new(e.value.as_ref(), e.value.span()));
         MetricValueDef {
             name: e.value,
-            value: Expr::from(ExprLit {
-                attrs: vec![],
-                lit: value_lit,
-            }),
+            value: LitStr::new(e.value.as_ref(), e.value.span()),
         }
     }
 }
@@ -125,7 +121,7 @@ impl MetricValueDefList {
         self.0.iter().map(|v| &v.name).collect()
     }
 
-    pub fn get_values<'a>(&'a self) -> Vec<&'a Expr> {
+    pub fn get_values<'a>(&'a self) -> Vec<&'a LitStr> {
         self.0.iter().map(|v| &v.value).collect()
     }
 }

--- a/static-metric/tests/label_enum.rs
+++ b/static-metric/tests/label_enum.rs
@@ -1,0 +1,48 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(proc_macro)]
+
+extern crate prometheus;
+extern crate prometheus_static_metric;
+
+use prometheus_static_metric::make_static_metric;
+
+make_static_metric! {
+    pub label_enum Methods {
+        post,
+        get,
+        put,
+        delete,
+    }
+
+    pub label_enum MethodsWithName {
+        post: "post_name",
+    }
+}
+
+#[test]
+fn test_format() {
+    assert_eq!("post", format!("{}", Methods::post));
+    assert_eq!("post", format!("{:?}", Methods::post));
+    assert_eq!("delete", format!("{}", Methods::delete));
+    assert_eq!("delete", format!("{:?}", Methods::delete));
+    assert_eq!("post_name", format!("{}", MethodsWithName::post));
+    assert_eq!("post_name", format!("{:?}", MethodsWithName::post));
+}
+
+#[test]
+fn test_equal() {
+    assert_eq!(Methods::post, Methods::post);
+    assert_ne!(Methods::post, Methods::get);
+}

--- a/static-metric/tests/metric.rs
+++ b/static-metric/tests/metric.rs
@@ -1,0 +1,163 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(proc_macro)]
+
+extern crate prometheus;
+extern crate prometheus_static_metric;
+
+use prometheus::core::Collector;
+use prometheus::{Counter, CounterVec, Opts};
+use prometheus_static_metric::make_static_metric;
+
+make_static_metric! {
+    pub label_enum Methods {
+        post,
+        get,
+        put,
+        delete,
+    }
+
+    pub label_enum MethodsWithName {
+        post: "post_name",
+        get: "get_name",
+        put,
+        delete,
+    }
+
+    pub struct SimpleCounterVec: Counter {
+        "method" => Methods,
+        "product" => {
+            foo,
+            bar,
+        },
+    }
+
+    pub struct ComplexCounterVec: Counter {
+        "method" => MethodsWithName,
+        "product" => {
+            foo,
+            bar: "bar_name",
+        },
+    }
+}
+
+/// Helper method to get a label values of a `Counter`.
+fn get_labels(counter: &Counter) -> Vec<String> {
+    counter.collect()[0].get_metric()[0]
+        .get_label()
+        .into_iter()
+        .map(|label| label.get_value().to_string())
+        .collect()
+}
+
+#[test]
+fn test_fields() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method", "product"]).unwrap();
+    let metric = SimpleCounterVec::from(&vec);
+    assert_eq!(get_labels(&metric.post.foo), vec!["post", "foo"]);
+    assert_eq!(get_labels(&metric.put.bar), vec!["put", "bar"]);
+}
+
+#[test]
+fn test_field_value() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method", "product"]).unwrap();
+    let metric = ComplexCounterVec::from(&vec);
+    assert_eq!(get_labels(&metric.post.foo), vec!["post_name", "foo"]);
+    assert_eq!(get_labels(&metric.put.bar), vec!["put", "bar_name"]);
+}
+
+#[test]
+fn test_label_order() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["product", "method"]).unwrap();
+    let metric = SimpleCounterVec::from(&vec);
+    assert_eq!(get_labels(&metric.post.foo), vec!["post", "foo"]);
+    assert_eq!(get_labels(&metric.put.bar), vec!["put", "bar"]);
+}
+
+#[test]
+#[should_panic]
+fn test_wrong_label_1() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method_foo", "product"]).unwrap();
+    SimpleCounterVec::from(&vec);
+}
+
+#[test]
+#[should_panic]
+fn test_wrong_label_2() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method", "product_foo"]).unwrap();
+    SimpleCounterVec::from(&vec);
+}
+
+#[test]
+fn test_try_get() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method", "product"]).unwrap();
+    let metric = SimpleCounterVec::from(&vec);
+    assert_eq!(
+        get_labels(&metric.try_get("get").unwrap().bar),
+        vec!["get", "bar"]
+    );
+    assert_eq!(
+        get_labels(&metric.get.try_get("bar").unwrap()),
+        vec!["get", "bar"]
+    );
+    assert_eq!(
+        get_labels(&metric.try_get("get").unwrap().try_get("bar").unwrap()),
+        vec!["get", "bar"]
+    );
+    assert!(metric.try_get("get_foo").is_none());
+    assert!(metric.try_get("get").unwrap().try_get("bar2").is_none());
+}
+
+#[test]
+fn test_try_get_with_field_value() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method", "product"]).unwrap();
+    let metric = ComplexCounterVec::from(&vec);
+    assert_eq!(
+        get_labels(&metric.try_get("get_name").unwrap().bar),
+        vec!["get_name", "bar_name"]
+    );
+    assert_eq!(
+        get_labels(&metric.get.try_get("bar_name").unwrap()),
+        vec!["get_name", "bar_name"]
+    );
+    assert_eq!(
+        get_labels(&metric
+            .try_get("get_name")
+            .unwrap()
+            .try_get("bar_name")
+            .unwrap()),
+        vec!["get_name", "bar_name"]
+    );
+    assert!(metric.try_get("get").is_none());
+}
+
+#[test]
+fn test_get() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method", "product"]).unwrap();
+    let metric = SimpleCounterVec::from(&vec);
+    assert_eq!(
+        get_labels(&metric.get(Methods::get).bar),
+        vec!["get", "bar"]
+    );
+}
+
+#[test]
+fn test_get_with_field_value() {
+    let vec = CounterVec::new(Opts::new("foo", "bar"), &["method", "product"]).unwrap();
+    let metric = ComplexCounterVec::from(&vec);
+    assert_eq!(
+        get_labels(&metric.get(MethodsWithName::get).bar),
+        vec!["get_name", "bar_name"]
+    );
+}


### PR DESCRIPTION
# RFC

## Background

When applying compile-time-unknown static metrics, currently we follow this style:

```rust
// Suppose we have `let label = "post"` elsewhere.
SOME_STATIC_VEC_METRIC.get(label).unwrap().inc();
```

As an equivalent to:

```rust
SOME_STATIC_VEC_METRIC.post.inc();
```

Since the value of `label` is unknown in compile time, we have to match it into the actual field at runtime, by using `.get(label).unwrap()`.

According to benchmark, this does not introduce notable overheads, which is good. However this cannot ensure safety: what if `label`'s value is not valid? This will lead to `unwrap()` panic.

From existing applications, we found out that in fact in most of the time we can make it safe in the compile time! We can simply assign an `enum` type for it.

## Design

For `label_enum` definitions, we expand it into real Rust `enum`s so that it can be used in the code elsewhere as a type-safe one:

```rust
make_static_metric! {
    pub label_enum Methods {
        post,
        get,
        put,
        delete,
    }
}
```

will be expand to:

```rust
#[derive(Debug, Clone, Copy, PartialEq)]
pub enum Methods {
    post,
    get,
    put,
    delete,
}
```

Next, we introduce our new `get()` function for metrics.

Take this definition as an example:

```rust
make_static_metric! {
    pub label_enum Methods {
        post,
        get,
        put,
        delete,
    }

    pub struct MyStaticCounterVec: Counter {
        "method" => Methods,
    }
}
```

The `get()` function of `MyStaticCounterVec` will be expanded as:

```rust
impl MyStaticCounterVec {
    pub fn get(&self, label: Methods): Counter {
        match label {
            Methods::post => self.post,
            Methods::get => self.get,
            Methods::put => self.put,
            Methods::delete => self.delete,
        }
    }
}
```

The old `get()` function will be renamed to `try_get` and other signatures remain unchanged.

If the label is provided inline like:

```rust
make_static_metric! {
    pub struct MyAnotherStaticCounterVec: IntCounter {
        "error" => {
            error_1,
            error_2,
        },
    }
}
```

`get()` will not be available and no enums will be generated accordingly.

---

During developing, I found out that some names need to be refined, otherwise there will be confusions. So this PR contains pretty much changes. However I organized my changes in commits so that you can review by commits, which is very friendly.

[Commit 1](https://github.com/pingcap/rust-prometheus/commit/c145f5c4186f564285461c49890634a0c565d27d) implements the RFC and is working (see example in the commit), exclude the derive part (see commit 4).
[Commit 2](https://github.com/pingcap/rust-prometheus/commit/a54af54c86d9f75225fc75efb16d8d79c4157feb) refines some misleading and confusing names in the parser to make it more clear. This commit does not provide new features.
[Commit 3](https://github.com/pingcap/rust-prometheus/commit/48a20d67b8ec210b27bf03040d9c8d26580e2621) adjusts acceptable expressions for the label value. Previously we accept `Expr`, which is any Rust expression. However in fact only string literals will work according to our implementations. So this commit changed `Expr` to `LitStr` to restrict the type.
[Commit 4](https://github.com/pingcap/rust-prometheus/commit/c9aa33ace2602d15b12065c5acfd656ffa7f52d4) implements Clone, Copy, Debug, Display, etc. for the enum.
[Commit 5](https://github.com/pingcap/rust-prometheus/commit/22feeb1855172f0eb451fcbbb9e3767b76d56e94) adds tests to further ensure stability and quality.