### PR TITLE
TLS & Basic Auth support to push mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.4.3
+## 0.5.0
 
 - Change: Added TLS and BasicAuthentication support to `push` client.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.3
+
+- Change: Added TLS and BasicAuthentication support to `push` client.
+
 ## 0.4.2
 
 - Change: Update to use protobuf 2.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ travis-ci = { repository = "pingcap/rust-prometheus" }
 [features]
 default = []
 nightly = ["libc", "spin/unstable"]
-push = ["hyper", "libc"]
+push = ["reqwest", "libc"]
 process = ["libc", "procinfo"]
 gen = ["protobuf-codegen-pure"]
 
@@ -28,16 +28,10 @@ lazy_static = "0.2"
 libc = {version = "0.2", optional = true}
 cfg-if = "0.1"
 spin = {version = "0.4", default-features = false}
+reqwest = {version = "0.8.6", optional = true}
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = {version = "0.3", optional = true}
-
-[dependencies.hyper]
-version = "0.9"
-# disable hyper ssl
-#  refer to https://github.com/hyperium/hyper/issues/903#issuecomment-242798266
-default-features = false
-optional = true
 
 [dev-dependencies]
 getopts = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.4.3"
+version = "0.5.0"
 license = "Apache-2.0"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com", "vistaswx@gmail.com"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.4.2"
+version = "0.4.3"
 license = "Apache-2.0"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com", "vistaswx@gmail.com"]

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -70,6 +70,7 @@ fn main() {
             labels!{"instance".to_owned() => "HAL-9000".to_owned(),},
             &address,
             metric_familys,
+            None,
         ).unwrap();
     }
 

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -24,6 +24,7 @@ use std::thread;
 use std::time;
 
 use getopts::Options;
+use prometheus::BasicAuthentication;
 use prometheus::{Counter, Histogram};
 
 lazy_static! {
@@ -70,7 +71,10 @@ fn main() {
             labels!{"instance".to_owned() => "HAL-9000".to_owned(),},
             &address,
             metric_familys,
-            None,
+            Some(BasicAuthentication {
+                username: "user".to_owned(),
+                password: Some("pass".to_owned()),
+            }),
         ).unwrap();
     }
 

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -72,7 +72,7 @@ fn main() {
             metric_familys,
             Some(prometheus::BasicAuthentication {
                 username: "user".to_owned(),
-                password: Some("pass".to_owned()),
+                password: "pass".to_owned(),
             }),
         ).unwrap();
     }

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -24,7 +24,6 @@ use std::thread;
 use std::time;
 
 use getopts::Options;
-use prometheus::BasicAuthentication;
 use prometheus::{Counter, Histogram};
 
 lazy_static! {
@@ -71,7 +70,7 @@ fn main() {
             labels!{"instance".to_owned() => "HAL-9000".to_owned(),},
             &address,
             metric_familys,
-            Some(BasicAuthentication {
+            Some(prometheus::BasicAuthentication {
                 username: "user".to_owned(),
                 password: Some("pass".to_owned()),
             }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,9 @@ pub mod core {
     */
 
     pub use super::atomic64::*;
-    pub use super::counter::{GenericCounter, GenericCounterVec, GenericLocalCounter,
-                             GenericLocalCounterVec};
+    pub use super::counter::{
+        GenericCounter, GenericCounterVec, GenericLocalCounter, GenericLocalCounterVec,
+    };
     pub use super::desc::{Desc, Describer};
     pub use super::gauge::{GenericGauge, GenericGaugeVec};
     pub use super::metrics::{Collector, Metric, Opts};
@@ -87,16 +88,18 @@ pub mod core {
 
 pub use self::counter::{Counter, CounterVec, IntCounter, IntCounterVec};
 pub use self::encoder::Encoder;
-pub use self::encoder::{PROTOBUF_FORMAT, TEXT_FORMAT};
 pub use self::encoder::{ProtobufEncoder, TextEncoder};
+pub use self::encoder::{PROTOBUF_FORMAT, TEXT_FORMAT};
 pub use self::errors::{Error, Result};
 pub use self::gauge::{Gauge, GaugeVec, IntGauge, IntGaugeVec};
 pub use self::histogram::DEFAULT_BUCKETS;
-pub use self::histogram::{Histogram, HistogramOpts, HistogramTimer, HistogramVec};
 pub use self::histogram::{exponential_buckets, linear_buckets};
+pub use self::histogram::{Histogram, HistogramOpts, HistogramTimer, HistogramVec};
 pub use self::metrics::Opts;
 #[cfg(feature = "push")]
-pub use self::push::{hostname_grouping_key, push_add_collector, push_add_metrics, push_collector,
-                     push_metrics};
+pub use self::push::{
+    hostname_grouping_key, push_add_collector, push_add_metrics, push_collector, push_metrics,
+    BasicAuthentication,
+};
 pub use self::registry::Registry;
 pub use self::registry::{gather, register, unregister};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ The Rust client library for [Prometheus](https://prometheus.io/).
 extern crate cfg_if;
 extern crate fnv;
 #[cfg(feature = "push")]
-extern crate hyper;
+extern crate reqwest;
 #[macro_use]
 extern crate lazy_static;
 #[cfg(any(feature = "nightly", feature = "push", feature = "process"))]

--- a/src/push.rs
+++ b/src/push.rs
@@ -35,9 +35,14 @@ lazy_static! {
         .unwrap();
 }
 
+/// `BasicAuthentication` holder for supporting `push` to Pushgateway endpoints
+/// using Basic access authentication.
+/// Can be passed to any `push_metrics` method.
 pub struct BasicAuthentication {
+    /// The Basic Authentication username (possibly empty string).
     pub username: String,
-    pub password: Option<String>,
+    /// The Basic Authentication password (possibly empty string).
+    pub password: String,
 }
 
 /// `push_metrics` pushes all gathered metrics to the Pushgateway specified by
@@ -159,9 +164,10 @@ fn push<S: BuildHasher>(
         .set(ContentType(encoder.format_type().parse().unwrap()));
 
     if let Some(BasicAuthentication { username, password }) = basic_auth {
-        request
-            .headers_mut()
-            .set(Authorization(Basic { username, password }))
+        request.headers_mut().set(Authorization(Basic {
+            username,
+            password: Some(password),
+        }))
     }
 
     *request.body_mut() = Some(Body::from(buf));

--- a/src/push.rs
+++ b/src/push.rs
@@ -158,12 +158,12 @@ fn push<S: BuildHasher>(
         .headers_mut()
         .set(ContentType(encoder.format_type().parse().unwrap()));
 
-    match basic_auth {
-        Some(BasicAuthentication { username, password }) => request
+    if let Some(BasicAuthentication { username, password }) = basic_auth {
+        request
             .headers_mut()
-            .set(Authorization(Basic { username, password })),
-        _ => (),
+            .set(Authorization(Basic { username, password }))
     }
+
     *request.body_mut() = Some(Body::from(buf));
 
     let response = HTTP_CLIENT


### PR DESCRIPTION
Looking at prometheus libraries in other languages, most seem to support `Basic Auth` & `TLS` when using `push` mode for pushing metrics to pushgateway. So adding support for both here as well.

Note:
- using `reqwest` instead of updating `hyper` to latest versions, which seemed simpler (`reqwest` api is also  really similar to `hyper`'s api from version 0.9)
- `reqwest` requires `openssl` on [linux](https://github.com/seanmonstar/reqwest#requirements) (as does `hyper-tls`)


Let me know if this seems useful & I will polish up the PR.