### PR TITLE
HistogramTimers should be #[must_use]

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -309,7 +309,7 @@ mod coarse {
 /// observe.
 ///
 /// NOTICE: A timer can be observed only once (automatically or manually).
-#[must_use]
+#[must_use = "Timer should be kept in a variable otherwise it cannot observe duration"]
 pub struct HistogramTimer {
     histogram: Histogram,
     start: Instant,
@@ -576,7 +576,7 @@ impl Clone for LocalHistogram {
 }
 
 /// An unsync [`HistogramTimer`](::HistogramTimer).
-#[must_use]
+#[must_use = "Timer should be kept in a variable otherwise it cannot observe duration"]
 pub struct LocalHistogramTimer {
     local: LocalHistogram,
     start: Instant,

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -308,6 +308,7 @@ mod coarse {
 /// observe.
 ///
 /// NOTICE: A timer can be observed only once (automatically or manually).
+#[must_use]
 pub struct HistogramTimer {
     histogram: Histogram,
     start: Instant,
@@ -574,6 +575,7 @@ impl Clone for LocalHistogram {
 }
 
 /// An unsync [`HistogramTimer`](::HistogramTimer).
+#[must_use]
 pub struct LocalHistogramTimer {
     local: LocalHistogram,
     start: Instant,


### PR DESCRIPTION
`HistogramTimers` should be either kept in a variable (so that it will not be immediately dropped), or manually call its `observe_duration()` interface. In this way, it should be marked as `#[must_use]`.

Resolve #145 
