### PR TITLE
Rename `with_opts` to `from_opts`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use prometheus::{Opts, Registry, Counter, TextEncoder, Encoder};
 
 // Create a Counter.
 let counter_opts = Opts::new("test_counter", "test counter help");
-let counter = Counter::with_opts(counter_opts).unwrap();
+let counter = Counter::from_opts(counter_opts).unwrap();
 
 // Create a Registry and register Counter.
 let r = Registry::new();

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -34,7 +34,7 @@ fn bench_histogram_with_label_values(b: &mut Bencher) {
 
 #[bench]
 fn bench_histogram_no_labels(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new(
+    let histogram = Histogram::from_opts(HistogramOpts::new(
         "benchmark_histogram",
         "A histogram to benchmark it.",
     )).unwrap();
@@ -43,7 +43,7 @@ fn bench_histogram_no_labels(b: &mut Bencher) {
 
 #[bench]
 fn bench_histogram_timer(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new(
+    let histogram = Histogram::from_opts(HistogramOpts::new(
         "benchmark_histogram_timer",
         "A histogram to benchmark it.",
     )).unwrap();
@@ -53,7 +53,7 @@ fn bench_histogram_timer(b: &mut Bencher) {
 #[bench]
 #[cfg(feature = "nightly")]
 fn bench_histogram_coarse_timer(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new(
+    let histogram = Histogram::from_opts(HistogramOpts::new(
         "benchmark_histogram_timer",
         "A histogram to benchmark it.",
     )).unwrap();
@@ -62,7 +62,7 @@ fn bench_histogram_coarse_timer(b: &mut Bencher) {
 
 #[bench]
 fn bench_histogram_local(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new(
+    let histogram = Histogram::from_opts(HistogramOpts::new(
         "benchmark_histogram_local",
         "A histogram to benchmark it.",
     )).unwrap();
@@ -73,7 +73,7 @@ fn bench_histogram_local(b: &mut Bencher) {
 
 #[bench]
 fn bench_local_histogram_timer(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new(
+    let histogram = Histogram::from_opts(HistogramOpts::new(
         "benchmark_histogram_local_timer",
         "A histogram to benchmark it.",
     )).unwrap();
@@ -85,7 +85,7 @@ fn bench_local_histogram_timer(b: &mut Bencher) {
 #[bench]
 #[cfg(feature = "nightly")]
 fn bench_local_histogram_coarse_timer(b: &mut Bencher) {
-    let histogram = Histogram::with_opts(HistogramOpts::new(
+    let histogram = Histogram::from_opts(HistogramOpts::new(
         "benchmark_histogram_timer",
         "A histogram to benchmark it.",
     )).unwrap();

--- a/examples/example_embed.rs
+++ b/examples/example_embed.rs
@@ -24,7 +24,7 @@ fn main() {
     let counter_opts = Opts::new("test_counter", "test counter help")
         .const_label("a", "1")
         .const_label("b", "2");
-    let counter = Counter::with_opts(counter_opts).unwrap();
+    let counter = Counter::from_opts(counter_opts).unwrap();
     let counter_vec_opts = Opts::new("test_counter_vec", "test counter vector help")
         .const_label("a", "1")
         .const_label("b", "2");
@@ -36,7 +36,7 @@ fn main() {
     let gauge_opts = Opts::new("test_gauge", "test gauge help")
         .const_label("a", "1")
         .const_label("b", "2");
-    let gauge = Gauge::with_opts(gauge_opts).unwrap();
+    let gauge = Gauge::from_opts(gauge_opts).unwrap();
     let gauge_vec_opts = Opts::new("test_gauge_vec", "test gauge vector help")
         .const_label("a", "1")
         .const_label("b", "2");

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -49,15 +49,15 @@ impl<P: Atomic> GenericCounter<P> {
     /// Create a [`GenericCounter`](::core::GenericCounter) with the `name` and `help` arguments.
     pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
         let opts = Opts::new(name, help);
-        Self::with_opts(opts)
+        Self::from_opts(opts)
     }
 
     /// Create a [`GenericCounter`](::core::GenericCounter) with the `opts` options.
-    pub fn with_opts(opts: Opts) -> Result<Self> {
-        Self::with_opts_and_label_values(&opts, &[])
+    pub fn from_opts(opts: Opts) -> Result<Self> {
+        Self::from_opts_and_label_values(&opts, &[])
     }
 
-    fn with_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> Result<Self> {
+    fn from_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> Result<Self> {
         let v = Value::new(opts, ValueType::Counter, P::T::from_i64(0), label_values)?;
         Ok(Self { v: Arc::new(v) })
     }
@@ -130,7 +130,7 @@ impl<P: Atomic> MetricVecBuilder for CounterVecBuilder<P> {
     type P = Opts;
 
     fn build(&self, opts: &Opts, vals: &[&str]) -> Result<Self::M> {
-        Self::M::with_opts_and_label_values(opts, vals)
+        Self::M::from_opts_and_label_values(opts, vals)
     }
 }
 
@@ -292,7 +292,7 @@ mod tests {
         let opts = Opts::new("test", "test help")
             .const_label("a", "1")
             .const_label("b", "2");
-        let counter = Counter::with_opts(opts).unwrap();
+        let counter = Counter::from_opts(opts).unwrap();
         counter.inc();
         assert_eq!(counter.get() as u64, 1);
         counter.inc_by(42.0);

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -252,7 +252,7 @@ mod tests {
         let counter_opts = Opts::new("test_counter", "test help")
             .const_label("a", "1")
             .const_label("b", "2");
-        let counter = Counter::with_opts(counter_opts).unwrap();
+        let counter = Counter::from_opts(counter_opts).unwrap();
         counter.inc();
 
         let mf = counter.collect();
@@ -270,7 +270,7 @@ test_counter{a="1",b="2"} 1
         let gauge_opts = Opts::new("test_gauge", "test help")
             .const_label("a", "1")
             .const_label("b", "2");
-        let gauge = Gauge::with_opts(gauge_opts).unwrap();
+        let gauge = Gauge::from_opts(gauge_opts).unwrap();
         gauge.inc();
         gauge.set(42.0);
 
@@ -289,7 +289,7 @@ test_gauge{a="1",b="2"} 42
     #[test]
     fn test_text_encoder_histogram() {
         let opts = HistogramOpts::new("test_histogram", "test help").const_label("a", "1");
-        let histogram = Histogram::with_opts(opts).unwrap();
+        let histogram = Histogram::from_opts(opts).unwrap();
         histogram.observe(0.25);
 
         let mf = histogram.collect();

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -48,15 +48,15 @@ impl<P: Atomic> GenericGauge<P> {
     /// Create a [`GenericGauge`](::core::GenericGauge) with the `name` and `help` arguments.
     pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
         let opts = Opts::new(name, help);
-        Self::with_opts(opts)
+        Self::from_opts(opts)
     }
 
     /// Create a [`GenericGauge`](::core::GenericGauge) with the `opts` options.
-    pub fn with_opts(opts: Opts) -> Result<Self> {
-        Self::with_opts_and_label_values(&opts, &[])
+    pub fn from_opts(opts: Opts) -> Result<Self> {
+        Self::from_opts_and_label_values(&opts, &[])
     }
 
-    fn with_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> Result<Self> {
+    fn from_opts_and_label_values(opts: &Opts, label_values: &[&str]) -> Result<Self> {
         let v = Value::new(opts, ValueType::Gauge, P::T::from_i64(0), label_values)?;
         Ok(Self { v: Arc::new(v) })
     }
@@ -139,7 +139,7 @@ impl<P: Atomic> MetricVecBuilder for GaugeVecBuilder<P> {
     type P = Opts;
 
     fn build(&self, opts: &Opts, vals: &[&str]) -> Result<Self::M> {
-        Self::M::with_opts_and_label_values(opts, vals)
+        Self::M::from_opts_and_label_values(opts, vals)
     }
 }
 
@@ -180,7 +180,7 @@ mod tests {
         let opts = Opts::new("test", "test help")
             .const_label("a", "1")
             .const_label("b", "2");
-        let gauge = Gauge::with_opts(opts).unwrap();
+        let gauge = Gauge::from_opts(opts).unwrap();
         gauge.inc();
         assert_eq!(gauge.get() as u64, 1);
         gauge.add(42.0);

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -368,12 +368,12 @@ pub struct Histogram {
 }
 
 impl Histogram {
-    /// `with_opts` creates a [`Histogram`](::Histogram) with the `opts` options.
-    pub fn with_opts(opts: HistogramOpts) -> Result<Histogram> {
-        Histogram::with_opts_and_label_values(&opts, &[])
+    /// Create a [`Histogram`](::Histogram) with the `opts` options.
+    pub fn from_opts(opts: HistogramOpts) -> Result<Histogram> {
+        Histogram::from_opts_and_label_values(&opts, &[])
     }
 
-    fn with_opts_and_label_values(
+    fn from_opts_and_label_values(
         opts: &HistogramOpts,
         label_values: &[&str],
     ) -> Result<Histogram> {
@@ -445,7 +445,7 @@ impl MetricVecBuilder for HistogramVecBuilder {
     type P = HistogramOpts;
 
     fn build(&self, opts: &HistogramOpts, vals: &[&str]) -> Result<Histogram> {
-        Histogram::with_opts_and_label_values(opts, vals)
+        Histogram::from_opts_and_label_values(opts, vals)
     }
 }
 
@@ -769,7 +769,7 @@ mod tests {
         let opts = HistogramOpts::new("test1", "test help")
             .const_label("a", "1")
             .const_label("b", "2");
-        let histogram = Histogram::with_opts(opts).unwrap();
+        let histogram = Histogram::from_opts(opts).unwrap();
         histogram.observe(1.0);
 
         let timer = histogram.start_timer();
@@ -796,7 +796,7 @@ mod tests {
 
         let buckets = vec![1.0, 2.0, 3.0];
         let opts = HistogramOpts::new("test2", "test help").buckets(buckets.clone());
-        let histogram = Histogram::with_opts(opts).unwrap();
+        let histogram = Histogram::from_opts(opts).unwrap();
         let mut mfs = histogram.collect();
         assert_eq!(mfs.len(), 1);
 
@@ -813,7 +813,7 @@ mod tests {
     #[cfg(feature = "nightly")]
     fn test_histogram_coarse_timer() {
         let opts = HistogramOpts::new("test1", "test help");
-        let histogram = Histogram::with_opts(opts).unwrap();
+        let histogram = Histogram::from_opts(opts).unwrap();
 
         let timer = histogram.start_coarse_timer();
         thread::sleep(Duration::from_millis(100));
@@ -932,7 +932,7 @@ mod tests {
     }
 
     #[test]
-    fn test_histogram_vec_with_opts_buckets() {
+    fn test_histogram_vec_from_opts_buckets() {
         let labels = ["l1", "l2"];
         let buckets = vec![1.0, 2.0, 3.0];
         let vec = HistogramVec::new(
@@ -958,7 +958,7 @@ mod tests {
         let buckets = vec![1.0, 2.0, 3.0];
         let opts = HistogramOpts::new("test_histogram_local", "test histogram local help")
             .buckets(buckets.clone());
-        let histogram = Histogram::with_opts(opts).unwrap();
+        let histogram = Histogram::from_opts(opts).unwrap();
         let local = histogram.local();
 
         let check = |count, sum| {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -153,7 +153,7 @@ macro_rules! histogram_opts {
 #[doc(hidden)]
 macro_rules! __register_counter {
     ($TYPE:ident, $OPTS:expr) => {{
-        let counter = $crate::$TYPE::with_opts($OPTS).unwrap();
+        let counter = $crate::$TYPE::from_opts($OPTS).unwrap();
         $crate::register(Box::new(counter.clone())).map(|_| counter)
     }};
 }
@@ -251,7 +251,7 @@ macro_rules! register_int_counter_vec {
 #[doc(hidden)]
 macro_rules! __register_gauge {
     ($TYPE:ident, $OPTS:expr) => {{
-        let gauge = $crate::$TYPE::with_opts($OPTS).unwrap();
+        let gauge = $crate::$TYPE::from_opts($OPTS).unwrap();
         $crate::register(Box::new(gauge.clone())).map(|_| gauge)
     }};
 }
@@ -376,7 +376,7 @@ macro_rules! register_histogram {
     };
 
     ($HOPTS:expr) => {{
-        let histogram = $crate::Histogram::with_opts($HOPTS).unwrap();
+        let histogram = $crate::Histogram::from_opts($HOPTS).unwrap();
         $crate::register(Box::new(histogram.clone())).map(|_| histogram)
     }};
 }

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -55,7 +55,7 @@ impl ProcessCollector {
         let namespace = namespace.into();
         let mut descs = Vec::new();
 
-        let cpu_total = Counter::with_opts(
+        let cpu_total = Counter::from_opts(
             Opts::new(
                 "process_cpu_seconds_total",
                 "Total user and system CPU time spent in \
@@ -64,13 +64,13 @@ impl ProcessCollector {
         ).unwrap();
         descs.extend(cpu_total.desc().into_iter().cloned());
 
-        let open_fds = Gauge::with_opts(
+        let open_fds = Gauge::from_opts(
             Opts::new("process_open_fds", "Number of open file descriptors.")
                 .namespace(namespace.clone()),
         ).unwrap();
         descs.extend(open_fds.desc().into_iter().cloned());
 
-        let max_fds = Gauge::with_opts(
+        let max_fds = Gauge::from_opts(
             Opts::new(
                 "process_max_fds",
                 "Maximum number of open file descriptors.",
@@ -78,7 +78,7 @@ impl ProcessCollector {
         ).unwrap();
         descs.extend(max_fds.desc().into_iter().cloned());
 
-        let vsize = Gauge::with_opts(
+        let vsize = Gauge::from_opts(
             Opts::new(
                 "process_virtual_memory_bytes",
                 "Virtual memory size in bytes.",
@@ -86,7 +86,7 @@ impl ProcessCollector {
         ).unwrap();
         descs.extend(vsize.desc().into_iter().cloned());
 
-        let rss = Gauge::with_opts(
+        let rss = Gauge::from_opts(
             Opts::new(
                 "process_resident_memory_bytes",
                 "Resident memory size in bytes.",
@@ -94,7 +94,7 @@ impl ProcessCollector {
         ).unwrap();
         descs.extend(rss.desc().into_iter().cloned());
 
-        let start_time = Gauge::with_opts(
+        let start_time = Gauge::from_opts(
             Opts::new(
                 "process_start_time_seconds",
                 "Start time of the process since unix epoch \


### PR DESCRIPTION
`from_opts` is a more accurate name because it creates a new instance, instead of modifying existing instance.

Extracted from https://github.com/pingcap/rust-prometheus/pull/197

This is a breaking change. However we have not published our 0.5 version yet (current published version is 0.4), so it's Ok and we don't need to bump to a new version.
