### PR TITLE
Provide Histogram::new and support different types for name and help

### DIFF
--- a/src/counter.rs
+++ b/src/counter.rs
@@ -47,7 +47,11 @@ impl<P: Atomic> Clone for GenericCounter<P> {
 
 impl<P: Atomic> GenericCounter<P> {
     /// Create a [`GenericCounter`](::core::GenericCounter) with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
+    pub fn new<A, B>(name: A, help: B) -> Result<Self>
+    where
+        A: Into<String>,
+        B: Into<String>,
+    {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -46,7 +46,11 @@ impl<P: Atomic> Clone for GenericGauge<P> {
 
 impl<P: Atomic> GenericGauge<P> {
     /// Create a [`GenericGauge`](::core::GenericGauge) with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Result<Self> {
+    pub fn new<A, B>(name: A, help: B) -> Result<Self>
+    where
+        A: Into<String>,
+        B: Into<String>,
+    {
         let opts = Opts::new(name, help);
         Self::with_opts(opts)
     }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -92,7 +92,11 @@ pub struct HistogramOpts {
 
 impl HistogramOpts {
     /// Create a [`HistogramOpts`](::HistogramOpts) with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> HistogramOpts {
+    pub fn new<A, B>(name: A, help: B) -> HistogramOpts
+    where
+        A: Into<String>,
+        B: Into<String>,
+    {
         HistogramOpts {
             common_opts: Opts::new(name, help),
             buckets: Vec::from(DEFAULT_BUCKETS as &'static [f64]),
@@ -118,7 +122,11 @@ impl HistogramOpts {
     }
 
     /// `const_label` adds a const label.
-    pub fn const_label<S: Into<String>>(mut self, name: S, value: S) -> Self {
+    pub fn const_label<A, B>(mut self, name: A, value: B) -> Self
+    where
+        A: Into<String>,
+        B: Into<String>,
+    {
         self.common_opts = self.common_opts.const_label(name, value);
         self
     }
@@ -368,7 +376,17 @@ pub struct Histogram {
 }
 
 impl Histogram {
-    /// `with_opts` creates a [`Histogram`](::Histogram) with the `opts` options.
+    /// Create a [`Histogram`](::Histogram) with the `name` and `help` arguments.
+    pub fn new<A, B>(name: A, help: B) -> Result<Self>
+    where
+        A: Into<String>,
+        B: Into<String>,
+    {
+        let opts = HistogramOpts::new(name, help);
+        Self::with_opts(opts)
+    }
+
+    /// Create a [`Histogram`](::Histogram) with the `opts` options.
     pub fn with_opts(opts: HistogramOpts) -> Result<Histogram> {
         Histogram::with_opts_and_label_values(&opts, &[])
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -85,7 +85,11 @@ pub struct Opts {
 
 impl Opts {
     /// `new` creates the Opts with the `name` and `help` arguments.
-    pub fn new<S: Into<String>>(name: S, help: S) -> Opts {
+    pub fn new<A, B>(name: A, help: B) -> Opts
+    where
+        A: Into<String>,
+        B: Into<String>,
+    {
         Opts {
             namespace: "".to_owned(),
             subsystem: "".to_owned(),
@@ -115,7 +119,11 @@ impl Opts {
     }
 
     /// `const_label` adds a const label.
-    pub fn const_label<S: Into<String>>(mut self, name: S, value: S) -> Self {
+    pub fn const_label<A, B>(mut self, name: A, value: B) -> Self
+    where
+        A: Into<String>,
+        B: Into<String>,
+    {
         self.const_labels.insert(name.into(), value.into());
         self
     }


### PR DESCRIPTION
Extracted from https://github.com/pingcap/rust-prometheus/pull/197

This PR provides `Histogram::new()`, just like there is `Counter::new()` and `Gauge::new()`.

Also, this PR makes `name` and `help` parameter able to accept different types.