### PR TITLE
Rename to try_register and try_unregister

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let counter = Counter::with_opts(counter_opts).unwrap();
 
 // Create a Registry and register Counter.
 let r = Registry::new();
-r.register(Box::new(counter.clone())).unwrap();
+r.try_register(Box::new(counter.clone())).unwrap();
 
 // Inc.
 counter.inc();

--- a/examples/example_embed.rs
+++ b/examples/example_embed.rs
@@ -30,8 +30,8 @@ fn main() {
         .const_label("b", "2");
     let counter_vec = CounterVec::new(counter_vec_opts, &["c", "d"]).unwrap();
 
-    r.register(Box::new(counter.clone())).unwrap();
-    r.register(Box::new(counter_vec.clone())).unwrap();
+    r.try_register(Box::new(counter.clone())).unwrap();
+    r.try_register(Box::new(counter_vec.clone())).unwrap();
 
     let gauge_opts = Opts::new("test_gauge", "test gauge help")
         .const_label("a", "1")
@@ -42,8 +42,8 @@ fn main() {
         .const_label("b", "2");
     let gauge_vec = GaugeVec::new(gauge_vec_opts, &["c", "d"]).unwrap();
 
-    r.register(Box::new(gauge.clone())).unwrap();
-    r.register(Box::new(gauge_vec.clone())).unwrap();
+    r.try_register(Box::new(gauge.clone())).unwrap();
+    r.try_register(Box::new(gauge_vec.clone())).unwrap();
 
     counter.inc();
     assert_eq!(counter.get() as u64, 1);

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -65,7 +65,7 @@ mod tests {
                                  &["labelname"])
             .unwrap();
         let reg = registry::Registry::new();
-        reg.register(Box::new(cv.clone())).unwrap();
+        reg.try_register(Box::new(cv.clone())).unwrap();
 
         cv.get_metric_with_label_values(&["2230"]).unwrap().inc();
         let mf = reg.gather();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,4 +105,4 @@ pub use self::push::{
     BasicAuthentication,
 };
 pub use self::registry::Registry;
-pub use self::registry::{gather, register, unregister};
+pub use self::registry::{gather, register, try_register, try_unregister, unregister};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -154,7 +154,7 @@ macro_rules! histogram_opts {
 macro_rules! __register_counter {
     ($TYPE:ident, $OPTS:expr) => {{
         let counter = $crate::$TYPE::with_opts($OPTS).unwrap();
-        $crate::register(Box::new(counter.clone())).map(|_| counter)
+        $crate::try_register(Box::new(counter.clone())).map(|_| counter)
     }};
 }
 
@@ -203,7 +203,7 @@ macro_rules! register_int_counter {
 macro_rules! __register_counter_vec {
     ($TYPE:ident, $OPTS:expr, $LABELS_NAMES:expr) => {{
         let counter_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
-        $crate::register(Box::new(counter_vec.clone())).map(|_| counter_vec)
+        $crate::try_register(Box::new(counter_vec.clone())).map(|_| counter_vec)
     }};
 }
 
@@ -252,7 +252,7 @@ macro_rules! register_int_counter_vec {
 macro_rules! __register_gauge {
     ($TYPE:ident, $OPTS:expr) => {{
         let gauge = $crate::$TYPE::with_opts($OPTS).unwrap();
-        $crate::register(Box::new(gauge.clone())).map(|_| gauge)
+        $crate::try_register(Box::new(gauge.clone())).map(|_| gauge)
     }};
 }
 
@@ -301,7 +301,7 @@ macro_rules! register_int_gauge {
 macro_rules! __register_gauge_vec {
     ($TYPE:ident, $OPTS:expr, $LABELS_NAMES:expr) => {{
         let gauge_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
-        $crate::register(Box::new(gauge_vec.clone())).map(|_| gauge_vec)
+        $crate::try_register(Box::new(gauge_vec.clone())).map(|_| gauge_vec)
     }};
 }
 
@@ -377,7 +377,7 @@ macro_rules! register_histogram {
 
     ($HOPTS:expr) => {{
         let histogram = $crate::Histogram::with_opts($HOPTS).unwrap();
-        $crate::register(Box::new(histogram.clone())).map(|_| histogram)
+        $crate::try_register(Box::new(histogram.clone())).map(|_| histogram)
     }};
 }
 
@@ -407,7 +407,7 @@ macro_rules! register_histogram {
 macro_rules! register_histogram_vec {
     ($HOPTS:expr, $LABELS_NAMES:expr) => {{
         let histogram_vec = $crate::HistogramVec::new($HOPTS, $LABELS_NAMES).unwrap();
-        $crate::register(Box::new(histogram_vec.clone())).map(|_| histogram_vec)
+        $crate::try_register(Box::new(histogram_vec.clone())).map(|_| histogram_vec)
     }};
 
     ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr) => {{

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -277,7 +277,7 @@ mod tests {
         }
 
         let r = registry::Registry::new();
-        let res = r.register(Box::new(pc));
+        let res = r.try_register(Box::new(pc));
         assert!(res.is_ok());
     }
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -196,7 +196,7 @@ fn push_from_collector<S: BuildHasher>(
 ) -> Result<()> {
     let registry = Registry::new();
     for bc in collectors {
-        registry.register(bc)?;
+        registry.try_register(bc)?;
     }
 
     let mfs = registry.gather();


### PR DESCRIPTION
Extracted from https://github.com/pingcap/rust-prometheus/pull/197

This PR renames `(un)register` to `try_(un)register` to better conform Rust's naming convention. Also provides `(un)register` as `try_(un)register.unwrap()`. In this way, user can simply use `register` in most cases without adding `unwrap()`.