### PR TITLE
Provide (un)register functions for collectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,15 @@ features = ["gen"]
 ## Example
 
 ```rust
-use prometheus::{Opts, Registry, Counter, TextEncoder, Encoder};
+use prometheus::prelude::*;
+use prometheus::{Opts, Registry, Counter, TextEncoder};
 
-// Create a Counter.
-let counter_opts = Opts::new("test_counter", "test counter help");
-let counter = Counter::with_opts(counter_opts).unwrap();
-
-// Create a Registry and register Counter.
+// Create a Registry.
 let r = Registry::new();
-r.try_register(Box::new(counter.clone())).unwrap();
+
+// Create a Counter and register to the registry.
+let counter_opts = Opts::new("test_counter", "test counter help");
+let counter = Counter::with_opts(counter_opts).unwrap().register(r);
 
 // Inc.
 counter.inc();

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ let counter = Counter::with_opts(counter_opts).unwrap();
 
 // Create a Registry and register Counter.
 let r = Registry::new();
-r.register(Box::new(counter.clone())).unwrap();
+r.try_register(Box::new(counter.clone())).unwrap();
 
 // Inc.
 counter.inc();

--- a/examples/example_embed.rs
+++ b/examples/example_embed.rs
@@ -30,8 +30,8 @@ fn main() {
         .const_label("b", "2");
     let counter_vec = CounterVec::new(counter_vec_opts, &["c", "d"]).unwrap();
 
-    r.register(Box::new(counter.clone())).unwrap();
-    r.register(Box::new(counter_vec.clone())).unwrap();
+    r.try_register(Box::new(counter.clone())).unwrap();
+    r.try_register(Box::new(counter_vec.clone())).unwrap();
 
     let gauge_opts = Opts::new("test_gauge", "test gauge help")
         .const_label("a", "1")
@@ -42,8 +42,8 @@ fn main() {
         .const_label("b", "2");
     let gauge_vec = GaugeVec::new(gauge_vec_opts, &["c", "d"]).unwrap();
 
-    r.register(Box::new(gauge.clone())).unwrap();
-    r.register(Box::new(gauge_vec.clone())).unwrap();
+    r.try_register(Box::new(gauge.clone())).unwrap();
+    r.try_register(Box::new(gauge_vec.clone())).unwrap();
 
     counter.inc();
     assert_eq!(counter.get() as u64, 1);

--- a/examples/example_embed.rs
+++ b/examples/example_embed.rs
@@ -16,7 +16,8 @@ extern crate prometheus;
 use std::thread;
 use std::time::Duration;
 
-use prometheus::{Counter, CounterVec, Encoder, Gauge, GaugeVec, Opts, Registry, TextEncoder};
+use prometheus::prelude::*;
+use prometheus::{Counter, CounterVec, Gauge, GaugeVec, Opts, Registry, TextEncoder};
 
 fn main() {
     let r = Registry::new();

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -21,7 +21,8 @@ use hyper::header::ContentType;
 use hyper::mime::Mime;
 use hyper::server::{Request, Response, Server};
 
-use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder};
+use prometheus::prelude::*;
+use prometheus::{Counter, Gauge, HistogramVec, TextEncoder};
 
 lazy_static! {
     static ref HTTP_COUNTER: Counter = register_counter!(opts!(

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -18,7 +18,8 @@ fn main() {
     use std::thread;
     use std::time::Duration;
 
-    use prometheus::{self, Encoder};
+    use prometheus;
+    use prometheus::prelude::*;
 
     // A default ProcessCollector is registered automatically.
     let mut buffer = Vec::new();

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -65,7 +65,7 @@ mod tests {
                                  &["labelname"])
             .unwrap();
         let reg = registry::Registry::new();
-        reg.register(Box::new(cv.clone())).unwrap();
+        reg.try_register(Box::new(cv.clone())).unwrap();
 
         cv.get_metric_with_label_values(&["2230"]).unwrap().inc();
         let mf = reg.gather();

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -24,7 +24,7 @@ pub const PROTOBUF_FORMAT: &str = "application/vnd.google.protobuf; \
                                    proto=io.prometheus.client.MetricFamily; \
                                    encoding=delimited";
 
-/// An implementation of an [`Encoder`](::Encoder) that converts a `MetricFamily` proto message
+/// An implementation of an [`Encoder`](::core::Encoder) that converts a `MetricFamily` proto message
 /// into the binary wire format of protobuf.
 #[derive(Debug, Default)]
 pub struct ProtobufEncoder;

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -25,7 +25,7 @@ pub const TEXT_FORMAT: &str = "text/plain; version=0.0.4";
 
 const POSITIVE_INF: &str = "+Inf";
 
-/// An implementation of an [`Encoder`](::Encoder) that converts a `MetricFamily` proto message
+/// An implementation of an [`Encoder`](::core::Encoder) that converts a `MetricFamily` proto message
 /// into text format.
 #[derive(Debug, Default)]
 pub struct TextEncoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,13 +84,33 @@ pub mod core {
         GenericCounter, GenericCounterVec, GenericLocalCounter, GenericLocalCounterVec,
     };
     pub use super::desc::{Desc, Describer};
+    pub use super::encoder::Encoder;
     pub use super::gauge::{GenericGauge, GenericGaugeVec};
     pub use super::metrics::{Collector, Metric, Opts};
     pub use super::vec::{MetricVec, MetricVecBuilder};
 }
 
+pub mod prelude {
+    /*!
+
+    Useful traits prelude.
+
+    The purpose of this module is to alleviate imports of common traits by adding a glob import:
+
+    ```
+    # #![allow(unused_imports)]
+    use prometheus::prelude::*;
+    ```
+
+    */
+
+    // Rename these traits so that when user is importing via `prelude::*`, it will be
+    // less likely to cause name conflict.
+    pub use super::core::Collector as MetricCollector;
+    pub use super::core::Encoder as MetricFamilyEncoder;
+}
+
 pub use self::counter::{Counter, CounterVec, IntCounter, IntCounterVec};
-pub use self::encoder::Encoder;
 pub use self::encoder::{ProtobufEncoder, TextEncoder};
 pub use self::encoder::{PROTOBUF_FORMAT, TEXT_FORMAT};
 pub use self::errors::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,4 +105,4 @@ pub use self::push::{
     BasicAuthentication,
 };
 pub use self::registry::Registry;
-pub use self::registry::{gather, register, unregister};
+pub use self::registry::{gather, register, try_register, try_unregister, unregister};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -154,7 +154,7 @@ macro_rules! histogram_opts {
 macro_rules! __register_counter {
     ($TYPE:ident, $OPTS:expr) => {{
         let counter = $crate::$TYPE::with_opts($OPTS).unwrap();
-        $crate::register(Box::new(counter.clone())).map(|_| counter)
+        $crate::try_register(Box::new(counter.clone())).map(|_| counter)
     }};
 }
 
@@ -203,7 +203,7 @@ macro_rules! register_int_counter {
 macro_rules! __register_counter_vec {
     ($TYPE:ident, $OPTS:expr, $LABELS_NAMES:expr) => {{
         let counter_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
-        $crate::register(Box::new(counter_vec.clone())).map(|_| counter_vec)
+        $crate::try_register(Box::new(counter_vec.clone())).map(|_| counter_vec)
     }};
 }
 
@@ -252,7 +252,7 @@ macro_rules! register_int_counter_vec {
 macro_rules! __register_gauge {
     ($TYPE:ident, $OPTS:expr) => {{
         let gauge = $crate::$TYPE::with_opts($OPTS).unwrap();
-        $crate::register(Box::new(gauge.clone())).map(|_| gauge)
+        $crate::try_register(Box::new(gauge.clone())).map(|_| gauge)
     }};
 }
 
@@ -301,7 +301,7 @@ macro_rules! register_int_gauge {
 macro_rules! __register_gauge_vec {
     ($TYPE:ident, $OPTS:expr, $LABELS_NAMES:expr) => {{
         let gauge_vec = $crate::$TYPE::new($OPTS, $LABELS_NAMES).unwrap();
-        $crate::register(Box::new(gauge_vec.clone())).map(|_| gauge_vec)
+        $crate::try_register(Box::new(gauge_vec.clone())).map(|_| gauge_vec)
     }};
 }
 
@@ -377,7 +377,7 @@ macro_rules! register_histogram {
 
     ($HOPTS:expr) => {{
         let histogram = $crate::Histogram::with_opts($HOPTS).unwrap();
-        $crate::register(Box::new(histogram.clone())).map(|_| histogram)
+        $crate::try_register(Box::new(histogram.clone())).map(|_| histogram)
     }};
 }
 
@@ -407,7 +407,7 @@ macro_rules! register_histogram {
 macro_rules! register_histogram_vec {
     ($HOPTS:expr, $LABELS_NAMES:expr) => {{
         let histogram_vec = $crate::HistogramVec::new($HOPTS, $LABELS_NAMES).unwrap();
-        $crate::register(Box::new(histogram_vec.clone())).map(|_| histogram_vec)
+        $crate::try_register(Box::new(histogram_vec.clone())).map(|_| histogram_vec)
     }};
 
     ($NAME:expr, $HELP:expr, $LABELS_NAMES:expr) => {{

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -28,6 +28,86 @@ pub trait Collector: Sync + Send {
 
     /// Collect metrics.
     fn collect(&self) -> Vec<proto::MetricFamily>;
+
+    /// Alias of [`Registry::try_register`]. Register the collector to a registry.
+    fn try_register(self, registry: &super::Registry) -> Result<Self>
+    where
+        Self: 'static + Sized + Clone,
+    {
+        registry.try_register(Box::new(self.clone())).map(|_| self)
+    }
+
+    /// Alias of [`Registry::register`]. Register the collector to a registry.
+    /// Panics if there are errors.
+    fn register(self, registry: &super::Registry) -> Self
+    where
+        Self: 'static + Sized + Clone,
+    {
+        registry
+            .try_register(Box::new(self.clone()))
+            .map(|_| self)
+            .unwrap()
+    }
+
+    /// Alias of [`try_register`]. Register the collector to the default registry.
+    fn try_register_default(self) -> Result<Self>
+    where
+        Self: 'static + Sized + Clone,
+    {
+        ::try_register(Box::new(self.clone())).map(|_| self)
+    }
+
+    /// Alias of [`register`]. Register the collector to the default registry.
+    /// Panics if there are errors.
+    fn register_default(self) -> Self
+    where
+        Self: 'static + Sized + Clone,
+    {
+        ::try_register(Box::new(self.clone()))
+            .map(|_| self)
+            .unwrap()
+    }
+
+    /// Alias for [`Registry::try_unregister`]. Unregister the collector from a registry.
+    fn try_unregister(self, registry: &super::Registry) -> Result<Self>
+    where
+        Self: 'static + Sized + Clone,
+    {
+        registry
+            .try_unregister(Box::new(self.clone()))
+            .map(|_| self)
+    }
+
+    /// Alias for [`Registry::try_unregister`]. Unregister the collector from a registry.
+    /// Panics if there are errors.
+    fn unregister(self, registry: &super::Registry) -> Self
+    where
+        Self: 'static + Sized + Clone,
+    {
+        registry
+            .try_unregister(Box::new(self.clone()))
+            .map(|_| self)
+            .unwrap()
+    }
+
+    /// Alias for [`try_unregister`]. Unregister the collector from the default registry.
+    fn try_unregister_default(self) -> Result<Self>
+    where
+        Self: 'static + Sized + Clone,
+    {
+        ::try_unregister(Box::new(self.clone())).map(|_| self)
+    }
+
+    /// Alias for [`try_unregister`]. Unregister the collector from the default registry.
+    /// Panics if there are errors.
+    fn unregister_default(self) -> Self
+    where
+        Self: 'static + Sized + Clone,
+    {
+        ::try_unregister(Box::new(self.clone()))
+            .map(|_| self)
+            .unwrap()
+    }
 }
 
 /// An interface models a single sample value with its meta data being exported to Prometheus.

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -277,7 +277,7 @@ mod tests {
         }
 
         let r = registry::Registry::new();
-        let res = r.register(Box::new(pc));
+        let res = r.try_register(Box::new(pc));
         assert!(res.is_ok());
     }
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -196,7 +196,7 @@ fn push_from_collector<S: BuildHasher>(
 ) -> Result<()> {
     let registry = Registry::new();
     for bc in collectors {
-        registry.register(bc)?;
+        registry.try_register(bc)?;
     }
 
     let mfs = registry.gather();

--- a/static-metric/tests/metric.rs
+++ b/static-metric/tests/metric.rs
@@ -16,7 +16,7 @@
 extern crate prometheus;
 extern crate prometheus_static_metric;
 
-use prometheus::core::Collector;
+use prometheus::prelude::*;
 use prometheus::{Counter, CounterVec, Opts};
 use prometheus_static_metric::make_static_metric;
 


### PR DESCRIPTION
Extracted from https://github.com/pingcap/rust-prometheus/pull/197

Based on https://github.com/pingcap/rust-prometheus/pull/201

This PR provides `(try)_(un)register` for all collectors, so that the syntax looks nice even without macros. Macros will be fully removed after `From<Opts>` for collectors is implemented.

This PR also extracts common traits (Collector and Encoder) to `prometheus::prelude` module, so that user can easily import them via `use prometheus::prelude::*`.