### PR TITLE
Deny missing docs

### DIFF
--- a/src/atomic64/fallback.rs
+++ b/src/atomic64/fallback.rs
@@ -50,8 +50,11 @@ impl<T: Number> Atomic for RwlockAtomic<T> {
     }
 }
 
+/// A fallback atomic float for stable Rust.
 pub type AtomicF64 = RwlockAtomic<f64>;
 
+/// A fallback atomic signed integer for stable Rust.
 pub type AtomicI64 = RwlockAtomic<i64>;
 
+/// A fallback atomic unsigned integer for stable Rust.
 pub type AtomicU64 = RwlockAtomic<u64>;

--- a/src/atomic64/mod.rs
+++ b/src/atomic64/mod.rs
@@ -32,7 +32,7 @@ pub trait Number:
 {
     /// `std::convert::From<i64> for f64` is not implemented, so that we need to implement our own.
     fn from_i64(v: i64) -> Self;
-
+    /// Convert to a f64.
     fn into_f64(self) -> f64;
 }
 
@@ -75,11 +75,17 @@ impl Number for f64 {
 /// An interface for atomics. Used to generically model float metrics and integer metrics, i.e.
 /// [`Counter`](::Counter) and [`IntCounter`](::IntCounter).
 pub trait Atomic: Send + Sync {
+    /// The numeric type associated with this atomic.
     type T: Number;
+    /// Create a new atomic value.
     fn new(val: Self::T) -> Self;
+    /// Set the value to the provided value.
     fn set(&self, val: Self::T);
+    /// Get the value.
     fn get(&self) -> Self::T;
+    /// Increment the value by a given amount.
     fn inc_by(&self, delta: Self::T);
+    /// Decrement the value by a given amount.
     fn dec_by(&self, delta: Self::T);
 }
 

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -30,6 +30,7 @@ pub const PROTOBUF_FORMAT: &str = "application/vnd.google.protobuf; \
 pub struct ProtobufEncoder;
 
 impl ProtobufEncoder {
+    /// Create a new protobuf encoder.
     pub fn new() -> ProtobufEncoder {
         ProtobufEncoder
     }

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -31,6 +31,7 @@ const POSITIVE_INF: &str = "+Inf";
 pub struct TextEncoder;
 
 impl TextEncoder {
+    /// Create a new text encoder.
     pub fn new() -> TextEncoder {
         TextEncoder
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,23 +20,28 @@ quick_error!{
     /// The error types for prometheus.
     #[derive(Debug)]
     pub enum Error {
+        /// A duplicate metric collector has already been registered.
         AlreadyReg {
             description("duplicate metrics collector registration attempted")
         }
+        /// The label cardinality was inconsistent.
         InconsistentCardinality(expect: usize, got: usize) {
             description("inconsistent label cardinality")
             display("expect {} label values, but got {}", expect, got)
         }
+        /// An error message which is only a string.
         Msg(msg: String) {
             description(msg)
             display("Error: {}", msg)
         }
+        /// An error containing a [`std::io::Error`].
         Io(err: IoError) {
             from()
             cause(err)
             description(err.description())
             display("Io {}", err)
         }
+        /// An error containing a [`protobuf::Error`].
         Protobuf(err: ProtobufError) {
             from()
             cause(err)

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -80,13 +80,14 @@ fn check_and_adjust_buckets(mut buckets: Vec<f64>) -> Result<Vec<f64>> {
 /// optional and can safely be left at their zero value.
 #[derive(Clone)]
 pub struct HistogramOpts {
+    /// A container holding various options.
     pub common_opts: Opts,
 
-    // Defines the buckets into which observations are counted. Each
-    // element in the slice is the upper inclusive bound of a bucket. The
-    // values must be sorted in strictly increasing order. There is no need
-    // to add a highest bucket with +Inf bound, it will be added
-    // implicitly. The default value is DefBuckets.
+    /// Defines the buckets into which observations are counted. Each
+    /// element in the slice is the upper inclusive bound of a bucket. The
+    /// values must be sorted in strictly increasing order. There is no need
+    /// to add a highest bucket with +Inf bound, it will be added
+    /// implicitly. The default value is DefBuckets.
     pub buckets: Vec<f64>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@ This library supports four features:
     allow(needless_pass_by_value, new_without_default_derive)
 )]
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
+#![deny(missing_docs)]
 
 #[macro_use]
 extern crate cfg_if;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -45,7 +45,17 @@ pub struct Opts {
     /// name. Note that the fully-qualified name of the metric must be a
     /// valid Prometheus metric name.
     pub namespace: String,
+    /// namespace, subsystem, and name are components of the fully-qualified
+    /// name of the [`Metric`](::core::Metric) (created by joining these components with
+    /// "_"). Only Name is mandatory, the others merely help structuring the
+    /// name. Note that the fully-qualified name of the metric must be a
+    /// valid Prometheus metric name.
     pub subsystem: String,
+    /// namespace, subsystem, and name are components of the fully-qualified
+    /// name of the [`Metric`](::core::Metric) (created by joining these components with
+    /// "_"). Only Name is mandatory, the others merely help structuring the
+    /// name. Note that the fully-qualified name of the metric must be a
+    /// valid Prometheus metric name.
     pub name: String,
 
     /// help provides information about this metric. Mandatory!

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -27,7 +27,9 @@ use proto::{MetricFamily, MetricType};
 
 /// An interface for building a metric vector.
 pub trait MetricVecBuilder: Send + Sync + Clone {
+    /// The associated Metric collected.
     type M: Metric;
+    /// The associated describer.
     type P: Describer + Sync + Send + Clone;
 
     /// `build` builds a [`Metric`](::core::Metric) with option and corresponding label names.

--- a/static-metric/src/lib.rs
+++ b/static-metric/src/lib.rs
@@ -10,6 +10,29 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+/*!
+This crate provides staticly built metrics to your Prometheus application.
+
+This is useful since it reduces the amount of branching and processing needed at runtime to collect metrics.
+
+```rust
+#[macro_use] extern crate lazy_static;
+#[macro_use] extern crate prometheus;
+use prometheus::{self, IntCounter, TextEncoder, Encoder};
+
+lazy_static! {
+    static ref HIGH_FIVE_COUNTER: IntCounter =
+        register_int_counter!("highfives", "Number of high fives recieved").unwrap();
+}
+
+HIGH_FIVE_COUNTER.inc();
+assert_eq!(HIGH_FIVE_COUNTER.get(), 1);
+```
+
+Is it reccomended that you consult the [`prometheus` documentation for more information.](https://docs.rs/prometheus/)
+*/
+
 #[macro_use]
 extern crate lazy_static;
 extern crate proc_macro;


### PR DESCRIPTION
Deny missing docs on `prometheus`. Didn't do it to `prometheus-static` since it has many non-user facing things.