### PR TITLE
Remove internal __register_counter macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -149,15 +149,6 @@ macro_rules! histogram_opts {
     }};
 }
 
-#[macro_export]
-#[doc(hidden)]
-macro_rules! __register_counter {
-    ($TYPE:ident, $OPTS:expr) => {{
-        let counter = $crate::$TYPE::with_opts($OPTS).unwrap();
-        $crate::register(Box::new(counter.clone())).map(|_| counter)
-    }};
-}
-
 /// Create a [`Counter`](::Counter) and registers to default registry.
 ///
 /// # Examples
@@ -175,8 +166,13 @@ macro_rules! __register_counter {
 /// ```
 #[macro_export]
 macro_rules! register_counter {
+    (@of_type $TYPE:ident, $OPTS:expr) => {{
+        let counter = $crate::$TYPE::with_opts($OPTS).unwrap();
+        $crate::register(Box::new(counter.clone())).map(|_| counter)
+    }};
+
     ($OPTS:expr) => {{
-        __register_counter!(Counter, $OPTS)
+        register_counter!(@of_type Counter, $OPTS)
     }};
 
     ($NAME:expr, $HELP:expr) => {{
@@ -190,7 +186,7 @@ macro_rules! register_counter {
 #[macro_export]
 macro_rules! register_int_counter {
     ($OPTS:expr) => {{
-        __register_counter!(IntCounter, $OPTS)
+        register_counter!(@of_type IntCounter, $OPTS)
     }};
 
     ($NAME:expr, $HELP:expr) => {{


### PR DESCRIPTION
Rust 1.30 allows use of the `use` keyword to bring macros into scope as a replacement for the `#[macro_use]` attribute. With the implementation before this change, the `register_counter` macro was unusable when brought into scope with `use` unless you also brought the internal `__register_counter` macro into scope.

To fix this issue, I collapsed `__register_counter` into an [internal rule](https://danielkeep.github.io/tlborm/book/pat-internal-rules.html) of the public `register_counter` macro.