### PR TITLE
Use the 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/pingcap/rust-prometheus"
 homepage = "https://github.com/pingcap/rust-prometheus"
 documentation = "https://docs.rs/prometheus"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "pingcap/rust-prometheus" }

--- a/benches/atomic.rs
+++ b/benches/atomic.rs
@@ -14,13 +14,12 @@
 #![feature(test)]
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
 
-extern crate spin;
 extern crate test;
 
 #[path = "../src/atomic64/mod.rs"]
 mod atomic64;
 
-use atomic64::*;
+use crate::atomic64::*;
 use test::Bencher;
 
 #[bench]

--- a/benches/counter.rs
+++ b/benches/counter.rs
@@ -13,7 +13,6 @@
 
 #![feature(test)]
 
-extern crate prometheus;
 extern crate test;
 
 use std::collections::HashMap;

--- a/benches/gauge.rs
+++ b/benches/gauge.rs
@@ -13,7 +13,6 @@
 
 #![feature(test)]
 
-extern crate prometheus;
 extern crate test;
 
 use prometheus::{Gauge, GaugeVec, IntGauge, Opts};

--- a/benches/histogram.rs
+++ b/benches/histogram.rs
@@ -13,7 +13,6 @@
 
 #![feature(test)]
 
-extern crate prometheus;
 extern crate test;
 
 use prometheus::{Histogram, HistogramOpts, HistogramVec};

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,4 @@
 #[cfg(feature = "gen")]
-extern crate protobuf_codegen_pure;
-
-#[cfg(feature = "gen")]
 fn generate_protobuf_binding_file() {
     protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
         out_dir: "proto",

--- a/examples/example_embed.rs
+++ b/examples/example_embed.rs
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate prometheus;
-
 use std::thread;
 use std::time::Duration;
 

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate hyper;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]
@@ -50,7 +49,7 @@ fn main() {
     println!("listening addr {:?}", addr);
     Server::http(addr)
         .unwrap()
-        .handle(move |_: Request, mut res: Response| {
+        .handle(move |_: Request<'_, '_>, mut res: Response<'_>| {
             HTTP_COUNTER.inc();
             let timer = HTTP_REQ_HISTOGRAM.with_label_values(&["all"]).start_timer();
 

--- a/examples/example_process_collector.rs
+++ b/examples/example_process_collector.rs
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate prometheus;
-
 #[cfg(all(feature = "process", target_os = "linux"))]
 fn main() {
     use std::thread;

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -13,7 +13,6 @@
 
 #![cfg_attr(not(feature = "push"), allow(unused_imports, dead_code))]
 
-extern crate getopts;
 #[macro_use]
 extern crate lazy_static;
 #[macro_use]

--- a/proto/proto_model.rs
+++ b/proto/proto_model.rs
@@ -114,7 +114,7 @@ impl ::protobuf::Message for LabelPair {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -147,7 +147,7 @@ impl ::protobuf::Message for LabelPair {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.name.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -235,13 +235,13 @@ impl ::protobuf::Clear for LabelPair {
 }
 
 impl ::std::fmt::Debug for LabelPair {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for LabelPair {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -285,7 +285,7 @@ impl ::protobuf::Message for Gauge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -316,7 +316,7 @@ impl ::protobuf::Message for Gauge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.value {
             os.write_double(1, v)?;
         }
@@ -395,13 +395,13 @@ impl ::protobuf::Clear for Gauge {
 }
 
 impl ::std::fmt::Debug for Gauge {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Gauge {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -445,7 +445,7 @@ impl ::protobuf::Message for Counter {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -476,7 +476,7 @@ impl ::protobuf::Message for Counter {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.value {
             os.write_double(1, v)?;
         }
@@ -555,13 +555,13 @@ impl ::protobuf::Clear for Counter {
 }
 
 impl ::std::fmt::Debug for Counter {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Counter {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -625,7 +625,7 @@ impl ::protobuf::Message for Quantile {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -666,7 +666,7 @@ impl ::protobuf::Message for Quantile {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.quantile {
             os.write_double(1, v)?;
         }
@@ -754,13 +754,13 @@ impl ::protobuf::Clear for Quantile {
 }
 
 impl ::std::fmt::Debug for Quantile {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Quantile {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -855,7 +855,7 @@ impl ::protobuf::Message for Summary {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -903,7 +903,7 @@ impl ::protobuf::Message for Summary {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.sample_count {
             os.write_uint64(1, v)?;
         }
@@ -1002,13 +1002,13 @@ impl ::protobuf::Clear for Summary {
 }
 
 impl ::std::fmt::Debug for Summary {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Summary {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1052,7 +1052,7 @@ impl ::protobuf::Message for Untyped {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1083,7 +1083,7 @@ impl ::protobuf::Message for Untyped {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.value {
             os.write_double(1, v)?;
         }
@@ -1162,13 +1162,13 @@ impl ::protobuf::Clear for Untyped {
 }
 
 impl ::std::fmt::Debug for Untyped {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Untyped {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1263,7 +1263,7 @@ impl ::protobuf::Message for Histogram {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1311,7 +1311,7 @@ impl ::protobuf::Message for Histogram {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.sample_count {
             os.write_uint64(1, v)?;
         }
@@ -1410,13 +1410,13 @@ impl ::protobuf::Clear for Histogram {
 }
 
 impl ::std::fmt::Debug for Histogram {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Histogram {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1480,7 +1480,7 @@ impl ::protobuf::Message for Bucket {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1521,7 +1521,7 @@ impl ::protobuf::Message for Bucket {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.cumulative_count {
             os.write_uint64(1, v)?;
         }
@@ -1609,13 +1609,13 @@ impl ::protobuf::Clear for Bucket {
 }
 
 impl ::std::fmt::Debug for Bucket {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Bucket {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -1885,7 +1885,7 @@ impl ::protobuf::Message for Metric {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -1958,7 +1958,7 @@ impl ::protobuf::Message for Metric {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         for v in &self.label {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2103,13 +2103,13 @@ impl ::protobuf::Clear for Metric {
 }
 
 impl ::std::fmt::Debug for Metric {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for Metric {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -2258,7 +2258,7 @@ impl ::protobuf::Message for MetricFamily {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
@@ -2304,7 +2304,7 @@ impl ::protobuf::Message for MetricFamily {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.name.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -2412,13 +2412,13 @@ impl ::protobuf::Clear for MetricFamily {
 }
 
 impl ::std::fmt::Debug for MetricFamily {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         ::protobuf::text_format::fmt(self, f)
     }
 }
 
 impl ::protobuf::reflect::ProtobufValue for MetricFamily {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Message(self)
     }
 }
@@ -2476,7 +2476,7 @@ impl ::std::marker::Copy for MetricType {
 }
 
 impl ::protobuf::reflect::ProtobufValue for MetricType {
-    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef {
+    fn as_ref(&self) -> ::protobuf::reflect::ProtobufValueRef<'_> {
         ::protobuf::reflect::ProtobufValueRef::Enum(self.descriptor())
     }
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,0 @@
-reorder_imports = true
-use_try_shorthand = true

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -16,13 +16,13 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use atomic64::{Atomic, AtomicF64, AtomicI64, Number};
-use desc::Desc;
-use errors::Result;
-use metrics::{Collector, Metric, Opts};
-use proto;
-use value::{Value, ValueType};
-use vec::{MetricVec, MetricVecBuilder};
+use crate::atomic64::{Atomic, AtomicF64, AtomicI64, Number};
+use crate::desc::Desc;
+use crate::errors::Result;
+use crate::metrics::{Collector, Metric, Opts};
+use crate::proto;
+use crate::value::{Value, ValueType};
+use crate::vec::{MetricVec, MetricVecBuilder};
 
 /// The underlying implementation for [`Counter`](::Counter) and [`IntCounter`](::IntCounter).
 #[derive(Debug)]
@@ -283,7 +283,7 @@ impl<P: Atomic> Clone for GenericLocalCounterVec<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use metrics::{Collector, Opts};
+    use crate::metrics::{Collector, Opts};
     use std::collections::HashMap;
     use std::f64::EPSILON;
 

--- a/src/desc.rs
+++ b/src/desc.rs
@@ -17,9 +17,9 @@ use std::hash::Hasher;
 
 use fnv::FnvHasher;
 
-use errors::{Error, Result};
-use metrics::SEPARATOR_BYTE;
-use proto::LabelPair;
+use crate::errors::{Error, Result};
+use crate::metrics::SEPARATOR_BYTE;
+use crate::proto::LabelPair;
 
 // TODO: use `char::is_ascii` instead once it landed in the stable rust.
 // Refer to https://github.com/rust-lang/rust/blob/
@@ -35,7 +35,7 @@ fn is_valid_metric_name(name: &str) -> bool {
     fn valid_start(c: char) -> bool {
         is_ascii(c)
             && match c as u8 {
-                b'a'...b'z' | b'A'...b'Z' | b'_' | b':' => true,
+                b'a'..=b'z' | b'A'..=b'Z' | b'_' | b':' => true,
                 _ => false,
             }
     }
@@ -43,7 +43,7 @@ fn is_valid_metric_name(name: &str) -> bool {
     fn valid_char(c: char) -> bool {
         is_ascii(c)
             && match c as u8 {
-                b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'_' | b':' => true,
+                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' | b':' => true,
                 _ => false,
             }
     }
@@ -56,7 +56,7 @@ fn is_valid_label_name(name: &str) -> bool {
     fn valid_start(c: char) -> bool {
         is_ascii(c)
             && match c as u8 {
-                b'a'...b'z' | b'A'...b'Z' | b'_' => true,
+                b'a'..=b'z' | b'A'..=b'Z' | b'_' => true,
                 _ => false,
             }
     }
@@ -64,7 +64,7 @@ fn is_valid_label_name(name: &str) -> bool {
     fn valid_char(c: char) -> bool {
         is_ascii(c)
             && match c as u8 {
-                b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'_' => true,
+                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'_' => true,
                 _ => false,
             }
     }
@@ -222,8 +222,8 @@ pub trait Describer {
 #[cfg(test)]
 mod tests {
 
-    use desc::{is_valid_label_name, is_valid_metric_name, Desc};
-    use errors::Error;
+    use crate::desc::{is_valid_label_name, is_valid_metric_name, Desc};
+    use crate::errors::Error;
     use std::collections::HashMap;
 
     #[test]

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -13,7 +13,7 @@
 
 use std::io::Write;
 
-use errors::{Error, Result};
+use crate::errors::{Error, Result};
 
 #[cfg(feature = "protobuf")]
 mod pb;
@@ -25,7 +25,7 @@ pub use self::pb::{ProtobufEncoder, PROTOBUF_FORMAT};
 
 pub use self::text::{TextEncoder, TEXT_FORMAT};
 
-use proto::MetricFamily;
+use crate::proto::MetricFamily;
 
 /// An interface for encoding metric families into an underlying wire protocol.
 pub trait Encoder {
@@ -35,7 +35,7 @@ pub trait Encoder {
     /// perform checks on the content of the metric and label names,
     /// i.e. invalid metric or label names will result in invalid text format
     /// output.
-    fn encode<W: Write>(&self, &[MetricFamily], &mut W) -> Result<()>;
+    fn encode<W: Write>(&self, _: &[MetricFamily], _: &mut W) -> Result<()>;
 
     /// `format_type` returns target format.
     fn format_type(&self) -> &str;
@@ -54,10 +54,10 @@ fn check_metric_family(mf: &MetricFamily) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use counter::CounterVec;
-    use encoder::Encoder;
-    use metrics::Collector;
-    use metrics::Opts;
+    use crate::counter::CounterVec;
+    use crate::encoder::Encoder;
+    use crate::metrics::Collector;
+    use crate::metrics::Opts;
 
     #[test]
     #[cfg(feature = "protobuf")]

--- a/src/encoder/pb.rs
+++ b/src/encoder/pb.rs
@@ -13,8 +13,8 @@
 
 use std::io::Write;
 
-use errors::Result;
-use proto::MetricFamily;
+use crate::errors::Result;
+use crate::proto::MetricFamily;
 use protobuf::Message;
 
 use super::{check_metric_family, Encoder};
@@ -53,10 +53,10 @@ impl Encoder for ProtobufEncoder {
 
 #[cfg(test)]
 mod tests {
-    use counter::CounterVec;
-    use encoder::Encoder;
-    use metrics::Opts;
-    use registry;
+    use crate::counter::CounterVec;
+    use crate::encoder::Encoder;
+    use crate::metrics::Opts;
+    use crate::registry;
 
     // TODO: add more tests.
     #[rustfmt::skip]

--- a/src/encoder/text.rs
+++ b/src/encoder/text.rs
@@ -13,10 +13,10 @@
 
 use std::io::Write;
 
-use errors::Result;
-use histogram::BUCKET_LABEL;
-use proto::MetricFamily;
-use proto::{self, MetricType};
+use crate::errors::Result;
+use crate::histogram::BUCKET_LABEL;
+use crate::proto::MetricFamily;
+use crate::proto::{self, MetricType};
 
 use super::{check_metric_family, Encoder};
 
@@ -133,7 +133,7 @@ fn write_sample(
     additional_label_name: &str,
     additional_label_value: &str,
     value: f64,
-    writer: &mut Write,
+    writer: &mut dyn Write,
 ) -> Result<()> {
     writer.write_all(name.as_bytes())?;
 
@@ -167,7 +167,7 @@ fn label_pairs_to_text(
     pairs: &[proto::LabelPair],
     additional_label_name: &str,
     additional_label_value: &str,
-    writer: &mut Write,
+    writer: &mut dyn Write,
 ) -> Result<()> {
     if pairs.is_empty() && additional_label_name.is_empty() {
         return Ok(());
@@ -229,10 +229,10 @@ fn escape_string(v: &str, include_double_quote: bool) -> String {
 mod tests {
 
     use super::*;
-    use counter::Counter;
-    use gauge::Gauge;
-    use histogram::{Histogram, HistogramOpts};
-    use metrics::{Collector, Opts};
+    use crate::counter::Counter;
+    use crate::gauge::Gauge;
+    use crate::histogram::{Histogram, HistogramOpts};
+    use crate::metrics::{Collector, Opts};
 
     #[test]
     fn test_ecape_string() {

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -15,13 +15,13 @@
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use atomic64::{Atomic, AtomicF64, AtomicI64, Number};
-use desc::Desc;
-use errors::Result;
-use metrics::{Collector, Metric, Opts};
-use proto;
-use value::{Value, ValueType};
-use vec::{MetricVec, MetricVecBuilder};
+use crate::atomic64::{Atomic, AtomicF64, AtomicI64, Number};
+use crate::desc::Desc;
+use crate::errors::Result;
+use crate::metrics::{Collector, Metric, Opts};
+use crate::proto;
+use crate::value::{Value, ValueType};
+use crate::vec::{MetricVec, MetricVecBuilder};
 
 /// The underlying implementation for [`Gauge`](::Gauge) and [`IntGauge`](::IntGauge).
 pub struct GenericGauge<P: Atomic> {
@@ -172,7 +172,7 @@ impl<P: Atomic> GenericGaugeVec<P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use metrics::{Collector, Opts};
+    use crate::metrics::{Collector, Opts};
     use std::collections::HashMap;
 
     #[test]

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -18,13 +18,13 @@ use std::convert::From;
 use std::sync::Arc;
 use std::time::{Duration, Instant as StdInstant};
 
-use atomic64::{Atomic, AtomicF64, AtomicU64};
-use desc::{Desc, Describer};
-use errors::{Error, Result};
-use metrics::{Collector, Metric, Opts};
-use proto;
-use value::make_label_pairs;
-use vec::{MetricVec, MetricVecBuilder};
+use crate::atomic64::{Atomic, AtomicF64, AtomicU64};
+use crate::desc::{Desc, Describer};
+use crate::errors::{Error, Result};
+use crate::metrics::{Collector, Metric, Opts};
+use crate::proto;
+use crate::value::make_label_pairs;
+use crate::vec::{MetricVec, MetricVecBuilder};
 
 /// The default [`Histogram`](::Histogram) buckets. The default buckets are
 /// tailored to broadly measure the response time (in seconds) of a
@@ -758,8 +758,8 @@ impl Clone for LocalHistogramVec {
 mod tests {
 
     use super::*;
-    use metrics::Collector;
-    use metrics::Metric;
+    use crate::metrics::Collector;
+    use crate::metrics::Metric;
     use std::f64::{EPSILON, INFINITY};
     use std::thread;
     use std::time::Duration;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,13 +107,10 @@ This library supports four features:
 
 */
 
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(
-        clippy::needless_pass_by_value,
-        clippy::new_without_default_derive,
-        clippy::new_ret_no_self
-    )
+#![allow(
+    clippy::needless_pass_by_value,
+    clippy::new_without_default,
+    clippy::new_ret_no_self
 )]
 #![cfg_attr(feature = "nightly", feature(integer_atomics))]
 #![deny(missing_docs)]
@@ -144,20 +141,10 @@ macro_rules! from_vec {
 
 #[macro_use]
 extern crate cfg_if;
-extern crate fnv;
-#[cfg(feature = "push")]
-extern crate reqwest;
 #[macro_use]
 extern crate lazy_static;
-#[cfg(any(feature = "nightly", feature = "push", feature = "process"))]
-extern crate libc;
-#[cfg(all(feature = "process", target_os = "linux"))]
-extern crate procinfo;
-#[cfg(feature = "protobuf")]
-extern crate protobuf;
 #[macro_use]
 extern crate quick_error;
-extern crate spin;
 
 mod encoder;
 mod errors;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,9 +15,9 @@
 use std::cmp::{Eq, Ord, Ordering, PartialOrd};
 use std::collections::HashMap;
 
-use desc::{Desc, Describer};
-use errors::Result;
-use proto::{self, LabelPair};
+use crate::desc::{Desc, Describer};
+use crate::errors::Result;
+use crate::proto::{self, LabelPair};
 
 pub const SEPARATOR_BYTE: u8 = 0xFF;
 
@@ -199,7 +199,7 @@ fn build_fq_name(namespace: &str, subsystem: &str, name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use proto::LabelPair;
+    use crate::proto::LabelPair;
     use std::cmp::{Ord, Ordering};
 
     fn new_label_pair(name: &str, value: &str) -> LabelPair {

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -22,12 +22,12 @@ use std::sync::Mutex;
 use libc;
 use procinfo::pid as pid_info;
 
-use counter::Counter;
-use desc::Desc;
-use errors::{Error, Result};
-use gauge::Gauge;
-use metrics::{Collector, Opts};
-use proto;
+use crate::counter::Counter;
+use crate::desc::Desc;
+use crate::errors::{Error, Result};
+use crate::gauge::Gauge;
+use crate::metrics::{Collector, Opts};
+use crate::proto;
 
 /// The `pid_t` data type represents process IDs.
 pub use libc::pid_t;
@@ -272,8 +272,8 @@ lazy_static! {
 mod tests {
 
     use super::*;
-    use metrics::Collector;
-    use registry;
+    use crate::metrics::Collector;
+    use crate::registry;
     use std::f64::EPSILON;
 
     #[test]

--- a/src/push.rs
+++ b/src/push.rs
@@ -20,11 +20,11 @@ use std::time::Duration;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::{Client, Method, StatusCode, Url};
 
-use encoder::{Encoder, ProtobufEncoder};
-use errors::{Error, Result};
-use metrics::Collector;
-use proto;
-use registry::Registry;
+use crate::encoder::{Encoder, ProtobufEncoder};
+use crate::errors::{Error, Result};
+use crate::metrics::Collector;
+use crate::proto;
+use crate::registry::Registry;
 
 const REQWEST_TIMEOUT_SEC: Duration = Duration::from_secs(10);
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use atomic64::{Atomic, Number};
-use desc::{Desc, Describer};
-use errors::{Error, Result};
-use proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
+use crate::atomic64::{Atomic, Number};
+use crate::desc::{Desc, Describer};
+use crate::errors::{Error, Result};
+use crate::proto::{Counter, Gauge, LabelPair, Metric, MetricFamily, MetricType};
 
 /// `ValueType` is an enumeration of metric types that represent a simple value
 /// for [`Counter`](::Counter) and [`Gauge`](::Gauge).

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -19,10 +19,10 @@ use std::sync::Arc;
 use fnv::FnvHasher;
 use spin::RwLock;
 
-use desc::{Desc, Describer};
-use errors::{Error, Result};
-use metrics::{Collector, Metric};
-use proto::{MetricFamily, MetricType};
+use crate::desc::{Desc, Describer};
+use crate::errors::{Error, Result};
+use crate::metrics::{Collector, Metric};
+use crate::proto::{MetricFamily, MetricType};
 
 /// An interface for building a metric vector.
 pub trait MetricVecBuilder: Send + Sync + Clone {
@@ -32,7 +32,7 @@ pub trait MetricVecBuilder: Send + Sync + Clone {
     type P: Describer + Sync + Send + Clone;
 
     /// `build` builds a [`Metric`](::core::Metric) with option and corresponding label names.
-    fn build(&self, &Self::P, &[&str]) -> Result<Self::M>;
+    fn build(&self, _: &Self::P, _: &[&str]) -> Result<Self::M>;
 }
 
 pub(crate) struct MetricVecCore<T: MetricVecBuilder> {
@@ -306,9 +306,9 @@ impl<T: MetricVecBuilder> Collector for MetricVec<T> {
 #[cfg(test)]
 mod tests {
 
-    use counter::CounterVec;
-    use gauge::GaugeVec;
-    use metrics::{Metric, Opts};
+    use crate::counter::CounterVec;
+    use crate::gauge::GaugeVec;
+    use crate::metrics::{Metric, Opts};
     use std::collections::HashMap;
 
     #[test]


### PR DESCRIPTION
Also fixes up the Clippy attribute and removes rustfmt.toml