### PR TITLE
prometheus: expose the default registry

### DIFF
--- a/examples/example_custom_registry.rs
+++ b/examples/example_custom_registry.rs
@@ -1,0 +1,69 @@
+// Copyright 2019 - rust-prometheus authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This examples shows how to use multiple and custom registries,
+//! and how to perform registration across function boundaries.
+
+#[macro_use]
+extern crate lazy_static;
+extern crate prometheus;
+
+use prometheus::{Encoder, IntCounter, Registry};
+
+lazy_static! {
+    static ref DEFAULT_COUNTER: IntCounter = IntCounter::new("default", "generic counter").unwrap();
+    static ref CUSTOM_COUNTER: IntCounter = IntCounter::new("custom", "dedicated counter").unwrap();
+}
+
+fn main() {
+    // Register default metrics.
+    default_metrics(prometheus::default_registry());
+
+    // Register custom metrics.
+    let custom_registry = Registry::new();
+    custom_metrics(&custom_registry);
+
+    // Print metrics for the default registry.
+    let mut buffer = Vec::<u8>::new();
+    let encoder = prometheus::TextEncoder::new();
+    encoder.encode(&prometheus::gather(), &mut buffer).unwrap();
+    println!("## Default registry");
+    println!("{}", String::from_utf8(buffer.clone()).unwrap());
+
+    // Print metrics for the custom registry.
+    let mut buffer = Vec::<u8>::new();
+    let encoder = prometheus::TextEncoder::new();
+    encoder
+        .encode(&custom_registry.gather(), &mut buffer)
+        .unwrap();
+    println!("## Custom registry");
+    println!("{}", String::from_utf8(buffer.clone()).unwrap());
+}
+
+/// Default metrics, to be collected by the default registry.
+fn default_metrics(registry: &Registry) {
+    registry
+        .register(Box::new(DEFAULT_COUNTER.clone()))
+        .unwrap();
+
+    DEFAULT_COUNTER.inc();
+    assert_eq!(DEFAULT_COUNTER.get(), 1);
+}
+
+/// Custom metrics, to be collected by a dedicated registry.
+fn custom_metrics(registry: &Registry) {
+    registry.register(Box::new(CUSTOM_COUNTER.clone())).unwrap();
+
+    CUSTOM_COUNTER.inc_by(42);
+    assert_eq!(CUSTOM_COUNTER.get(), 42);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,4 +227,4 @@ pub use self::push::{
     BasicAuthentication,
 };
 pub use self::registry::Registry;
-pub use self::registry::{gather, register, unregister};
+pub use self::registry::{default_registry, gather, register, unregister};

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -268,6 +268,12 @@ lazy_static! {
     };
 }
 
+/// Default registry (global static).
+pub fn default_registry() -> &'static Registry {
+    lazy_static::initialize(&DEFAULT_REGISTRY);
+    &DEFAULT_REGISTRY
+}
+
 /// Registers a new [`Collector`](::core::Collector) to be included in metrics collection. It
 /// returns an error if the descriptors provided by the [`Collector`](::core::Collector) are invalid or
 /// if they - in combination with descriptors of already registered Collectors -
@@ -335,9 +341,14 @@ mod tests {
 
         assert!(register(Box::new(counter.clone())).is_ok());
         assert_ne!(gather().len(), 0);
+        assert_ne!(default_registry().gather().len(), 0);
+        assert_eq!(gather().len(), default_registry().gather().len());
 
         assert!(unregister(Box::new(counter.clone())).is_ok());
         assert!(unregister(Box::new(counter.clone())).is_err());
+        assert!(default_registry()
+            .unregister(Box::new(counter.clone()))
+            .is_err());
         assert!(register(Box::new(counter.clone())).is_ok());
     }
 


### PR DESCRIPTION
This adds a getter to expose the default/static registry. It also includes an example showing how to use multiple and custom registries, and how to perform registration across function boundaries.

Closes: https://github.com/pingcap/rust-prometheus/issues/230
