### PR TITLE
clippy: fix renamed lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ This library supports four features:
     feature = "cargo-clippy",
     allow(
         clippy::needless_pass_by_value,
-        clippy::new_without_default_derive,
+        clippy::new_without_default,
         clippy::new_ret_no_self
     )
 )]


### PR DESCRIPTION
This fixes a clippy hard-failure due to a renamed lint:
```
error: lint `clippy::new_without_default_derive` has been renamed to `clippy::new_without_default`
```