### PR TITLE
Fix compilation without protobuf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,11 @@ addons:
       - gcc-multilib
 
 env:
+  matrix:
+    - FEATURES="protobuf push process"
+    - FEATURES=""
   global:
     - RUSTFLAGS=--deny=warnings
-    - FEATURES="push process"
     - ARCH=i686
 
 # Must be present for matrix.
@@ -35,7 +37,7 @@ matrix:
   - rust: nightly
 
 script:
-  - cargo test --features="$FEATURES"
+  - cargo test --no-default-features --features="$FEATURES"
   - |
     if [ $TRAVIS_RUST_VERSION = 'stable' ]; then
         # Clean up.

--- a/src/plain_model.rs
+++ b/src/plain_model.rs
@@ -267,6 +267,14 @@ impl Metric {
         self.label = v;
     }
 
+    pub fn mut_label(&mut self) -> &mut [LabelPair] {
+        &mut self.label
+    }
+
+    pub fn take_label(&mut self) -> Vec<LabelPair> {
+        ::std::mem::replace(&mut self.label, Vec::new())
+    }
+
     pub fn get_label(&self) -> &[LabelPair] {
         &self.label
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -197,7 +197,7 @@ impl RegistryCore {
                     let mut pairs: Vec<proto::LabelPair> = hmap
                         .iter()
                         .map(|(k, v)| {
-                            let mut label = proto::LabelPair::new();
+                            let mut label = proto::LabelPair::default();
                             label.set_name(k.to_string());
                             label.set_value(v.to_string());
                             label
@@ -205,7 +205,7 @@ impl RegistryCore {
                         .collect();
 
                     for metric in m.mut_metric().iter_mut() {
-                        let mut labels = metric.take_label().into_vec();
+                        let mut labels: Vec<_> = metric.take_label().into();
                         labels.append(&mut pairs);
                         metric.set_label(labels.into());
                     }
@@ -506,7 +506,7 @@ mod tests {
         assert_eq!(mfs.len(), 1);
         assert_eq!(mfs[0].get_name(), "test_a_counter");
 
-        let mut needle = proto::LabelPair::new();
+        let mut needle = proto::LabelPair::default();
         needle.set_name("tkey".to_string());
         needle.set_value("tvalue".to_string());
         let metrics = mfs[0].get_metric();


### PR DESCRIPTION
Compilation of the latest version (0.6.0) failed in one of my projects with the following error:

```
error[E0599]: no method named `take_label` found for type `&mut proto::Metric` in the current scope
   --> src/registry.rs:208:49
    |
208 |                         let mut labels = metric.take_label().into_vec();
    |                                                 ^^^^^^^^^^

error: aborting due to previous error
```

Upon investigation, I found out this happened if the crate was configured not to use the protobuf feature (e.g. with `default-features = false` when listed as a dependency, or with `cargo build --no-default-features`).

Further investigation revealed that the `Metric` implementation in `plain_model.rs` was missing the `mut_label` and `take_label` methods, which exist in the version defined in `proto/proto_model.rs`. Fixing that was easy enough, but required a small adaptation in `registry.rs`:

```diff
-                         let mut labels = metric.take_label().into_vec();
+                         let mut labels: Vec<_> = metric.take_label().into();
```

I also took the opportunity to fix the deprecation warning about `LabelPair::new`.

Please let me know if there's anything you wish I'd improve in this PR.