### PR TITLE
Provide immutable interface for local counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+- Provide immutable interface for local counters.
+
 ## 0.6.1
 
 - Fix compile error when ProtoBuf feature is not enabled (#240).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prometheus"
-version = "0.6.1"
+version = "0.7.0"
 license = "Apache-2.0"
 keywords = ["prometheus", "metrics"]
 authors = ["overvenus@gmail.com", "siddontang@gmail.com", "vistaswx@gmail.com"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The main Structures and APIs are ported from [Go client](https://github.com/prom
 
     ```toml
     [dependencies]
-    prometheus = "0.6"
+    prometheus = "0.7"
     ```
 
 + Add this to your crate in `lib.rs`:

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -328,8 +328,8 @@ mod tests {
     #[test]
     fn test_local_counter() {
         let counter = Counter::new("counter", "counter helper").unwrap();
-        let mut local_counter1 = counter.local();
-        let mut local_counter2 = counter.local();
+        let local_counter1 = counter.local();
+        let local_counter2 = counter.local();
 
         local_counter1.inc();
         local_counter2.inc();
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn test_int_local_counter() {
         let counter = IntCounter::new("foo", "bar").unwrap();
-        let mut local_counter = counter.local();
+        let local_counter = counter.local();
 
         local_counter.inc();
         assert_eq!(local_counter.get(), 1);
@@ -525,7 +525,7 @@ mod tests {
     #[should_panic(expected = "assertion failed")]
     fn test_local_counter_negative_inc() {
         let counter = Counter::new("foo", "bar").unwrap();
-        let mut local = counter.local();
+        let local = counter.local();
         local.inc_by(-42.0);
     }
 
@@ -542,7 +542,7 @@ mod tests {
     #[should_panic(expected = "assertion failed")]
     fn test_int_local_counter_negative_inc() {
         let counter = IntCounter::new("foo", "bar").unwrap();
-        let mut local = counter.local();
+        let local = counter.local();
         local.inc_by(-42);
     }
 }


### PR DESCRIPTION
When local metrics are used in thread local environments, it would be better to provide immutable interfaces, so that there is no need to wrap local metrics with a `RefCell`.

`LocalHistogram` is already immutable, so this PR makes `Local(Int)Counter` immutable.