### PR TITLE
Utilize prometheus 0.7 features

### DIFF
--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -23,7 +23,7 @@ quote = "0.5"
 lazy_static = "1.0"
 
 [dev-dependencies]
-prometheus = "^0"
+prometheus = "0.7"
 coarsetime = "0.1"
 
 [features]

--- a/static-metric/Makefile
+++ b/static-metric/Makefile
@@ -9,7 +9,7 @@ test:
 	cargo test --features="${ENABLE_FEATURES}" -- --nocapture
 
 format:
-	@cargo fmt --all -- --write-mode diff >/dev/null || cargo fmt --all
+	@cargo fmt --all -- --check >/dev/null || cargo fmt --all
 
 bench: format
 	RUSTFLAGS="--cfg bench" cargo bench --features="${ENABLE_FEATURES}" -- --nocapture

--- a/static-metric/examples/local.rs
+++ b/static-metric/examples/local.rs
@@ -18,7 +18,7 @@ extern crate prometheus;
 extern crate prometheus_static_metric;
 
 use coarsetime::Instant;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 
 use prometheus::*;
 use prometheus_static_metric::make_static_metric;
@@ -54,9 +54,7 @@ lazy_static! {
 thread_local! {
     static THREAD_LAST_TICK_TIME: Cell<Instant> = Cell::new(Instant::now());
 
-    pub static TLS_HTTP_COUNTER: RefCell<LocalHttpRequestStatistics> = RefCell::new(
-        LocalHttpRequestStatistics::from(&HTTP_COUNTER_VEC)
-    );
+    pub static TLS_HTTP_COUNTER: LocalHttpRequestStatistics = LocalHttpRequestStatistics::from(&HTTP_COUNTER_VEC);
 }
 
 pub fn may_flush_metrics() {
@@ -67,16 +65,16 @@ pub fn may_flush_metrics() {
             return;
         }
         tls_last_tick.set(now);
-        TLS_HTTP_COUNTER.with(|m| m.borrow_mut().flush());
+        TLS_HTTP_COUNTER.with(|m| m.flush());
     });
 }
 
 /// This example demonstrates the usage of using static metrics with local metrics.
 
 fn main() {
-    TLS_HTTP_COUNTER.with(|m| m.borrow_mut().foo.post.http1.inc());
-    TLS_HTTP_COUNTER.with(|m| m.borrow_mut().foo.post.http1.inc());
-    TLS_HTTP_COUNTER.with(|m| m.borrow_mut().foo.post.http1.inc());
+    TLS_HTTP_COUNTER.with(|m| m.foo.post.http1.inc());
+    TLS_HTTP_COUNTER.with(|m| m.foo.post.http1.inc());
+    TLS_HTTP_COUNTER.with(|m| m.foo.post.http1.inc());
 
     assert_eq!(
         HTTP_COUNTER_VEC

--- a/static-metric/src/builder.rs
+++ b/static-metric/src/builder.rs
@@ -353,12 +353,11 @@ impl<'a> MetricBuilderContext<'a> {
     }
 
     fn build_impl_flush(&self) -> Tokens {
-        // TODO: Remove this &mut in body
         if util::is_local_metric(self.metric.metric_type) {
             let value_def_list = self.label.get_value_def_list(self.enum_definitions);
             let names = value_def_list.get_names();
             quote! {
-                pub fn flush(&mut self) {
+                pub fn flush(&self) {
                     #(self.#names.flush();)*
                 }
             }

--- a/static-metric/tests/label_enum.rs
+++ b/static-metric/tests/label_enum.rs
@@ -11,8 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(proc_macro)]
-
 extern crate prometheus;
 extern crate prometheus_static_metric;
 


### PR DESCRIPTION
rust-prometheus 0.7 provides immutable local counter, so that the macro can be simplified.