### PR TITLE
Allow omitting trailing commas in labels macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,26 +33,18 @@
 /// ```
 #[macro_export]
 macro_rules! labels {
-    () => {
-        {
-            use std::collections::HashMap;
-
-            HashMap::new()
-        }
-    };
-
-    ( $ ( $ KEY : expr => $ VALUE : expr , ) + ) => {
+    ( $( $ KEY : expr => $ VALUE : expr ),* $(,)? ) => {
         {
             use std::collections::HashMap;
 
             let mut lbs = HashMap::new();
             $(
                 lbs.insert($KEY, $VALUE);
-            )+
+            )*
 
             lbs
         }
-    }
+    };
 }
 
 /// Create an [`Opts`](::Opts).


### PR DESCRIPTION
This small PR allows for trailing commas to be omitted when using the `labels!` macro. It also tidies up the logic a little bit.