### PR TITLE
lib: deny missing Debug implementations

### DIFF
--- a/src/atomic64.rs
+++ b/src/atomic64.rs
@@ -82,6 +82,7 @@ pub trait Atomic: Send + Sync {
 }
 
 /// A atomic float.
+#[derive(Debug)]
 pub struct AtomicF64 {
     inner: StdAtomicU64,
 }
@@ -136,6 +137,7 @@ impl Atomic for AtomicF64 {
 }
 
 /// A atomic signed integer.
+#[derive(Debug)]
 pub struct AtomicI64 {
     inner: StdAtomicI64,
 }
@@ -171,6 +173,7 @@ impl Atomic for AtomicI64 {
 }
 
 /// A atomic unsigned integer.
+#[derive(Debug)]
 pub struct AtomicU64 {
     inner: StdAtomicU64,
 }

--- a/src/counter.rs
+++ b/src/counter.rs
@@ -114,6 +114,7 @@ impl<P: Atomic> Metric for GenericCounter<P> {
     }
 }
 
+#[derive(Debug)]
 pub struct CounterVecBuilder<P: Atomic> {
     _phantom: PhantomData<P>,
 }
@@ -175,6 +176,7 @@ impl<P: Atomic> GenericCounterVec<P> {
 
 /// The underlying implementation for [`LocalCounter`](::local::LocalCounter)
 /// and [`LocalIntCounter`](::local::LocalIntCounter).
+#[derive(Debug)]
 pub struct GenericLocalCounter<P: Atomic> {
     counter: GenericCounter<P>,
     val: RefCell<P::T>,
@@ -246,6 +248,16 @@ impl<P: Atomic> Clone for GenericLocalCounter<P> {
 pub struct GenericLocalCounterVec<P: Atomic> {
     vec: GenericCounterVec<P>,
     local: HashMap<u64, GenericLocalCounter<P>>,
+}
+
+impl<P: Atomic> std::fmt::Debug for GenericLocalCounterVec<P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "GenericLocalCounterVec ({} locals)",
+            self.local.keys().len()
+        )
+    }
 }
 
 /// An unsync [`CounterVec`](::CounterVec).

--- a/src/gauge.rs
+++ b/src/gauge.rs
@@ -24,6 +24,7 @@ use crate::value::{Value, ValueType};
 use crate::vec::{MetricVec, MetricVecBuilder};
 
 /// The underlying implementation for [`Gauge`](::Gauge) and [`IntGauge`](::IntGauge).
+#[derive(Debug)]
 pub struct GenericGauge<P: Atomic> {
     v: Arc<Value<P>>,
 }
@@ -116,6 +117,7 @@ impl<P: Atomic> Metric for GenericGauge<P> {
     }
 }
 
+#[derive(Debug)]
 pub struct GaugeVecBuilder<P: Atomic> {
     _phantom: PhantomData<P>,
 }

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -77,7 +77,7 @@ fn check_and_adjust_buckets(mut buckets: Vec<f64>) -> Result<Vec<f64>> {
 /// A struct that bundles the options for creating a [`Histogram`](::Histogram) metric. It is
 /// mandatory to set Name and Help to a non-empty string. All other fields are
 /// optional and can safely be left at their zero value.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct HistogramOpts {
     /// A container holding various options.
     pub common_opts: Opts,
@@ -162,6 +162,7 @@ impl From<Opts> for HistogramOpts {
     }
 }
 
+#[derive(Debug)]
 pub struct HistogramCore {
     desc: Desc,
     label_pairs: Vec<proto::LabelPair>,
@@ -237,6 +238,7 @@ impl HistogramCore {
     }
 }
 
+#[derive(Debug)]
 enum Instant {
     Monotonic(StdInstant),
     #[cfg(all(feature = "nightly", target_os = "linux"))]
@@ -310,6 +312,7 @@ mod coarse {
 /// goes out of scope) or manually.
 /// Alternatively, it can be manually stopped and discarded in order to not record its value.
 #[must_use = "Timer should be kept in a variable otherwise it cannot observe duration"]
+#[derive(Debug)]
 pub struct HistogramTimer {
     /// An histogram for automatic recording of observations.
     histogram: Histogram,
@@ -394,7 +397,7 @@ impl Drop for HistogramTimer {
 /// buckets, and they are in general less accurate. The Observe method of a
 /// [`Histogram`](::Histogram) has a very low performance overhead in comparison with the Observe
 /// method of a Summary.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Histogram {
     core: Arc<HistogramCore>,
 }
@@ -469,7 +472,7 @@ impl Collector for Histogram {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct HistogramVecBuilder {}
 
 impl MetricVecBuilder for HistogramVecBuilder {
@@ -585,7 +588,7 @@ fn duration_to_seconds(d: Duration) -> f64 {
     d.as_secs() as f64 + nanos
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct LocalHistogramCore {
     histogram: Histogram,
     counts: Vec<u64>,
@@ -594,6 +597,7 @@ pub struct LocalHistogramCore {
 }
 
 /// An unsync [`Histogram`](::Histogram).
+#[derive(Debug)]
 pub struct LocalHistogram {
     core: RefCell<LocalHistogramCore>,
 }
@@ -609,6 +613,7 @@ impl Clone for LocalHistogram {
 
 /// An unsync [`HistogramTimer`](::HistogramTimer).
 #[must_use = "Timer should be kept in a variable otherwise it cannot observe duration"]
+#[derive(Debug)]
 pub struct LocalHistogramTimer {
     /// A local histogram for automatic recording of observations.
     local: LocalHistogram,
@@ -784,6 +789,7 @@ impl Drop for LocalHistogram {
 }
 
 /// An unsync [`HistogramVec`](::HistogramVec).
+#[derive(Debug)]
 pub struct LocalHistogramVec {
     vec: HistogramVec,
     local: HashMap<u64, LocalHistogram>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ This library supports four features:
     clippy::new_ret_no_self
 )]
 #![deny(missing_docs)]
+#![deny(missing_debug_implementations)]
 
 /// Protocol buffers format of metrics.
 #[cfg(feature = "protobuf")]

--- a/src/process_collector.rs
+++ b/src/process_collector.rs
@@ -38,6 +38,7 @@ const MERTICS_NUMBER: usize = 6;
 /// A collector which exports the current state of
 /// process metrics including cpu, memory and file descriptor usage as well as
 /// the process start time for the given process id.
+#[derive(Debug)]
 pub struct ProcessCollector {
     pid: pid_t,
     descs: Vec<Desc>,

--- a/src/push.rs
+++ b/src/push.rs
@@ -38,6 +38,7 @@ lazy_static! {
 /// `BasicAuthentication` holder for supporting `push` to Pushgateway endpoints
 /// using Basic access authentication.
 /// Can be passed to any `push_metrics` method.
+#[derive(Debug)]
 pub struct BasicAuthentication {
     /// The Basic Authentication username (possibly empty string).
     pub username: String,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -33,6 +33,16 @@ struct RegistryCore {
     pub prefix: Option<String>,
 }
 
+impl std::fmt::Debug for RegistryCore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "RegistryCore ({} collectors)",
+            self.collectors_by_id.keys().len()
+        )
+    }
+}
+
 impl RegistryCore {
     fn register(&mut self, c: Box<dyn Collector>) -> Result<()> {
         let mut desc_id_set = HashSet::new();
@@ -218,7 +228,7 @@ impl RegistryCore {
 
 /// A struct for registering Prometheus collectors, collecting their metrics, and gathering
 /// them into `MetricFamilies` for exposition.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Registry {
     r: Arc<RwLock<RegistryCore>>,
 }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -35,6 +35,7 @@ pub trait MetricVecBuilder: Send + Sync + Clone {
     fn build(&self, _: &Self::P, _: &[&str]) -> Result<Self::M>;
 }
 
+#[derive(Debug)]
 pub(crate) struct MetricVecCore<T: MetricVecBuilder> {
     pub children: RwLock<HashMap<u64, T::M>>,
     pub desc: Desc,
@@ -184,6 +185,12 @@ impl<T: MetricVecBuilder> MetricVecCore<T> {
 #[derive(Clone)]
 pub struct MetricVec<T: MetricVecBuilder> {
     pub(crate) v: Arc<MetricVecCore<T>>,
+}
+
+impl<T: MetricVecBuilder> std::fmt::Debug for MetricVec<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MetricVec")
+    }
 }
 
 impl<T: MetricVecBuilder> MetricVec<T> {


### PR DESCRIPTION
This implements Debug on all public types that were missing it,
and adds a lint to force future types to implement it.