### PR TITLE
Avoid accumulating error in linear_buckets

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -531,14 +531,7 @@ pub fn linear_buckets(start: f64, width: f64, count: usize) -> Result<Vec<f64>> 
         )));
     }
 
-    let mut next = start;
-    let mut buckets = Vec::with_capacity(count);
-    for _ in 0..count {
-        buckets.push(next);
-        next += width;
-    }
-
-    Ok(buckets)
+    Ok((0..count).map(|step| start + step as f64 * width).collect())
 }
 
 /// Create `count` buckets, where the lowest bucket has an


### PR DESCRIPTION
The previous implementation of `linear_buckets` was prone to accumulate error. Consider for example:

```
linear_buckets(0.002, 0.002, 50) 
// => Ok([0.002, 0.004, 0.006, 0.008, 0.01, 0.012, 0.014, 0.016, 0.018000000000000002, 0.020000000000000004, 0.022000000000000006, 0.024000000000000007, 0.02600000000000001, 0.02800000000000001, 0.030000000000000013, 0.032000000000000015, 0.034000000000000016, 0.03600000000000002, 0.03800000000000002, 0.04000000000000002, 0.04200000000000002, 0.044000000000000025, 0.04600000000000003, 0.04800000000000003, 0.05000000000000003, 0.05200000000000003, 0.054000000000000034, 0.056000000000000036, 0.05800000000000004, 0.06000000000000004, 0.06200000000000004, 0.06400000000000004, 0.06600000000000004, 0.06800000000000005, 0.07000000000000005, 0.07200000000000005, 0.07400000000000005, 0.07600000000000005, 0.07800000000000006, 0.08000000000000006, 0.08200000000000006, 0.08400000000000006, 0.08600000000000006, 0.08800000000000006, 0.09000000000000007, 0.09200000000000007, 0.09400000000000007, 0.09600000000000007, 0.09800000000000007, 0.10000000000000007])
```

The new implementation avoids accumulating this error by multiplying by integer step for every step, resulting in significantly better behaved buckets:

```
Ok([0.002, 0.004, 0.006, 0.008, 0.01, 0.012, 0.014, 0.016, 0.018000000000000002, 0.020000000000000004, 0.022, 0.024, 0.026000000000000002, 0.028000000000000004, 0.03, 0.032, 0.034, 0.036000000000000004, 0.038000000000000006, 0.04, 0.042, 0.044000000000000004, 0.046, 0.048, 0.05, 0.052000000000000005, 0.054000000000000006, 0.056, 0.058, 0.060000000000000005, 0.062, 0.064, 0.066, 0.068, 0.07, 0.07200000000000001, 0.07400000000000001, 0.076, 0.078, 0.08, 0.082, 0.084, 0.08600000000000001, 0.08800000000000001, 0.09, 0.092, 0.094, 0.096, 0.098, 0.1])
```