### PR TITLE
Cargo.toml: Update procinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ spin = "0.5"
 reqwest = { version = "0.9.5", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-procinfo = { version = "0.3", optional = true }
+procinfo = { version = "0.4", optional = true }
 
 [dev-dependencies]
 getopts = "0.2"


### PR DESCRIPTION
Use a 2017 dependency instead of a 2016 dependency. :-P

This simplifies the build graph for projects using a modern procinfo like TiKV.
