### PR TITLE
Fix compile on nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
   fast_finish: true
   include:
   - rust: nightly
+  - rust: nightly
+    env: FEATURES="nightly protobuf push process"
   - rust: beta
   - rust: stable
     install:

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -652,7 +652,7 @@ impl LocalHistogramTimer {
     }
 
     #[cfg(feature = "nightly")]
-    fn new_coarse(histogram: Histogram) -> Self {
+    fn new_coarse(histogram: LocalHistogram) -> Self {
         Self {
             local: histogram,
             observed: false,


### PR DESCRIPTION
LocalHistogramTimer::new_coarse() should take a local histogram as an
arg.