### PR TITLE
Update spin dependency to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ fnv = "1.0"
 lazy_static = "1.3"
 libc = { version = "0.2", optional = true }
 cfg-if = "0.1"
-spin = "0.5"
+spin = "0.5.2"
 reqwest = { version = "0.9.5", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
A vulnerability was fixed in spin and is reported by cargo-audit. Although exploitation sounds unlikely, the warning shows up transitively for packages that depend on rust-prometheus, so updating it would be nice.

   https://rustsec.org/advisories/RUSTSEC-2019-0013.html