### PR TITLE
histogram: avoid accumulating error in linear buckets

### DIFF
--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -550,12 +550,9 @@ pub fn linear_buckets(start: f64, width: f64, count: usize) -> Result<Vec<f64>> 
         )));
     }
 
-    let mut next = start;
-    let mut buckets = Vec::with_capacity(count);
-    for _ in 0..count {
-        buckets.push(next);
-        next += width;
-    }
+    let buckets: Vec<_> = (0..count)
+        .map(|step| start + width * (step as f64))
+        .collect();
 
     Ok(buckets)
 }


### PR DESCRIPTION
The logic behind linear buckets is prone to accumulate error.
This tweaks the implementation to avoid that. It multiplies
by integer step for each iteration, resulting in better behaved
buckets.

Ref: https://github.com/pingcap/rust-prometheus/pull/266
Co-Developed-by: Simonas Kazlauskas <git@kazlauskas.me>
Signed-off-by: Luca Bruno <luca.bruno@coreos.com>