### PR TITLE
Update syn, quote, proc-macro2 to v1.0

### DIFF
--- a/static-metric/Cargo.toml
+++ b/static-metric/Cargo.toml
@@ -17,9 +17,9 @@ include = [
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15", features = ["full", "extra-traits"] }
-proc-macro2 = "0.4"
-quote = "0.6"
+syn = { version = "1.0", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0"
+quote = "1.0"
 lazy_static = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

I think it's time to update `syn`, `quote` and `proc-macro2` to v1.0.
`syn`, `quote` and `proc-macro2` in the upstream dependency of `rust-prometheus` have been upgraded to version 1.0.