### PR TITLE
feat: automatically convert Vec into HashMap in histogram_opts! macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -162,7 +162,14 @@ macro_rules! histogram_opts {
 
     ($NAME:expr, $HELP:expr, $BUCKETS:expr, $CONST_LABELS:expr $(,)?) => {{
         let hopts = histogram_opts!($NAME, $HELP, $BUCKETS);
-        hopts.const_labels($CONST_LABELS)
+        
+        let lbs = HashMap::<String, String>::new();
+        $(
+            let mut lbs = lbs;
+            lbs.extend($CONST_LABELS.iter().map(|(k, v)| ((*k).into(), (*v).into())));
+        )*
+
+        hopts.const_labels(lbs)
     }};
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -141,7 +141,7 @@ fn test_opts_trailing_comma() {
 /// let opts = histogram_opts!(name,
 ///                            help,
 ///                            vec![1.0, 2.0],
-///                            labels!{"key".to_string() => "value".to_string(),});
+///                            labels!{"key" => "value",});
 /// assert_eq!(opts.common_opts.name, name);
 /// assert_eq!(opts.common_opts.help, help);
 /// assert_eq!(opts.buckets.len(), 2);
@@ -160,9 +160,10 @@ macro_rules! histogram_opts {
         hopts.buckets($BUCKETS)
     }};
 
-    ($NAME:expr, $HELP:expr, $BUCKETS:expr, $CONST_LABELS:expr $(,)?) => {{
+    ($NAME:expr, $HELP:expr, $BUCKETS:expr $ ( , $CONST_LABELS:expr ) * $ ( , ) ? ) => {{
+        use std::collections::HashMap;
+
         let hopts = histogram_opts!($NAME, $HELP, $BUCKETS);
-        
         let lbs = HashMap::<String, String>::new();
         $(
             let mut lbs = lbs;
@@ -193,13 +194,16 @@ fn test_histogram_opts_trailing_comma() {
         name,
         help,
         vec![1.0, 2.0],
-        labels! {"key".to_string() => "value".to_string(),},
+        labels! {"key" => "value",},
+        labels! {"key2" => "value2",},
     );
     assert_eq!(opts.common_opts.name, name);
     assert_eq!(opts.common_opts.help, help);
     assert_eq!(opts.buckets.len(), 2);
     assert!(opts.common_opts.const_labels.get("key").is_some());
     assert_eq!(opts.common_opts.const_labels.get("key").unwrap(), "value");
+    assert!(opts.common_opts.const_labels.get("key2").is_some());
+    assert_eq!(opts.common_opts.const_labels.get("key2").unwrap(), "value2");
 }
 
 /// Create a [`Counter`] and registers to default registry.


### PR DESCRIPTION
I noticed that this happens in the `opts!` macro already so I think it makes sense for `histogram_opts!` to also do this.