### PR TITLE
official grafana cloud snap encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["protobuf"]
 gen = ["protobuf-codegen-pure"]
 nightly = ["libc"]
 process = ["libc", "procfs"]
-push = ["reqwest", "libc", "protobuf"]
+push = ["reqwest", "libc", "protobuf", "snap"]
 
 [dependencies]
 cfg-if = "^1.0"
@@ -31,6 +31,7 @@ lazy_static = "^1.4"
 libc = { version = "^0.2", optional = true }
 parking_lot = "^0.12"
 protobuf = { version = "^2.0", optional = true }
+snap = { version = "^1.1", optional = true }
 memchr = "^2.3"
 reqwest = { version = "^0.11", features = ["blocking"], optional = true }
 thiserror = "^1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ pub use self::pulling_gauge::PullingGauge;
 #[cfg(feature = "push")]
 pub use self::push::{
     hostname_grouping_key, push_add_collector, push_add_metrics, push_collector, push_metrics,
-    BasicAuthentication,
+    push_raw, BasicAuthentication,
 };
 pub use self::registry::Registry;
 pub use self::registry::{default_registry, gather, register, unregister};


### PR DESCRIPTION
grafana cloud push has only snap encoding and only one hardcoded url. 

so it fixes initial 404 against existing push (valid url) and 400 against snappy compression (no error not about snap, it was decompressed, but about proto. updating to version 3 is hard).

but it is great step forward push working on official cloud