### PR TITLE
docs: Promote the usage of LazyLock instead of lazy_static

### DIFF
--- a/examples/example_custom_registry.rs
+++ b/examples/example_custom_registry.rs
@@ -3,16 +3,14 @@
 //! This examples shows how to use multiple and custom registries,
 //! and how to perform registration across function boundaries.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 
 use prometheus::{Encoder, IntCounter, Registry};
 
-use lazy_static::lazy_static;
-
-lazy_static! {
-    static ref DEFAULT_COUNTER: IntCounter = IntCounter::new("default", "generic counter").unwrap();
-    static ref CUSTOM_COUNTER: IntCounter = IntCounter::new("custom", "dedicated counter").unwrap();
-}
+static DEFAULT_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| IntCounter::new("default", "generic counter").unwrap());
+static CUSTOM_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| IntCounter::new("custom", "dedicated counter").unwrap());
 
 fn main() {
     // Register default metrics.

--- a/examples/example_hyper.rs
+++ b/examples/example_hyper.rs
@@ -1,6 +1,7 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::net::SocketAddr;
+use std::sync::LazyLock;
 
 use hyper::body::Incoming;
 use hyper::header::CONTENT_TYPE;
@@ -9,33 +10,36 @@ use hyper::service::service_fn;
 use hyper::Request;
 use hyper::Response;
 use hyper_util::rt::TokioIo;
-use lazy_static::lazy_static;
 use prometheus::{labels, opts, register_counter, register_gauge, register_histogram_vec};
 use prometheus::{Counter, Encoder, Gauge, HistogramVec, TextEncoder};
 use tokio::net::TcpListener;
 
 type BoxedErr = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-lazy_static! {
-    static ref HTTP_COUNTER: Counter = register_counter!(opts!(
+static HTTP_COUNTER: LazyLock<Counter> = LazyLock::new(|| {
+    register_counter!(opts!(
         "example_http_requests_total",
         "Number of HTTP requests made.",
         labels! {"handler" => "all",}
     ))
-    .unwrap();
-    static ref HTTP_BODY_GAUGE: Gauge = register_gauge!(opts!(
+    .unwrap()
+});
+static HTTP_BODY_GAUGE: LazyLock<Gauge> = LazyLock::new(|| {
+    register_gauge!(opts!(
         "example_http_response_size_bytes",
         "The HTTP response sizes in bytes.",
         labels! {"handler" => "all",}
     ))
-    .unwrap();
-    static ref HTTP_REQ_HISTOGRAM: HistogramVec = register_histogram_vec!(
+    .unwrap()
+});
+static HTTP_REQ_HISTOGRAM: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
         "example_http_request_duration_seconds",
         "The HTTP request latencies in seconds.",
         &["handler"]
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 async fn serve_req(_req: Request<Incoming>) -> Result<Response<String>, BoxedErr> {
     let encoder = TextEncoder::new();

--- a/examples/example_int_metrics.rs
+++ b/examples/example_int_metrics.rs
@@ -1,21 +1,22 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::LazyLock;
+
 use prometheus::{IntCounter, IntCounterVec, IntGauge, IntGaugeVec};
 
-use lazy_static::lazy_static;
 use prometheus::{
     register_int_counter, register_int_counter_vec, register_int_gauge, register_int_gauge_vec,
 };
 
-lazy_static! {
-    static ref A_INT_COUNTER: IntCounter =
-        register_int_counter!("A_int_counter", "foobar").unwrap();
-    static ref A_INT_COUNTER_VEC: IntCounterVec =
-        register_int_counter_vec!("A_int_counter_vec", "foobar", &["a", "b"]).unwrap();
-    static ref A_INT_GAUGE: IntGauge = register_int_gauge!("A_int_gauge", "foobar").unwrap();
-    static ref A_INT_GAUGE_VEC: IntGaugeVec =
-        register_int_gauge_vec!("A_int_gauge_vec", "foobar", &["a", "b"]).unwrap();
-}
+static A_INT_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| register_int_counter!("A_int_counter", "foobar").unwrap());
+static A_INT_COUNTER_VEC: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!("A_int_counter_vec", "foobar", &["a", "b"]).unwrap()
+});
+static A_INT_GAUGE: LazyLock<IntGauge> =
+    LazyLock::new(|| register_int_gauge!("A_int_gauge", "foobar").unwrap());
+static A_INT_GAUGE_VEC: LazyLock<IntGaugeVec> =
+    LazyLock::new(|| register_int_gauge_vec!("A_int_gauge_vec", "foobar", &["a", "b"]).unwrap());
 
 fn main() {
     A_INT_COUNTER.inc();

--- a/examples/example_push.rs
+++ b/examples/example_push.rs
@@ -1,27 +1,29 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
 use std::env;
+use std::sync::LazyLock;
 use std::thread;
 use std::time;
 
 use getopts::Options;
 use prometheus::{Counter, Histogram};
 
-use lazy_static::lazy_static;
 use prometheus::{labels, register_counter, register_histogram};
 
-lazy_static! {
-    static ref PUSH_COUNTER: Counter = register_counter!(
+static PUSH_COUNTER: LazyLock<Counter> = LazyLock::new(|| {
+    register_counter!(
         "example_push_total",
         "Total number of prometheus client pushed."
     )
-    .unwrap();
-    static ref PUSH_REQ_HISTOGRAM: Histogram = register_histogram!(
+    .unwrap()
+});
+static PUSH_REQ_HISTOGRAM: LazyLock<Histogram> = LazyLock::new(|| {
+    register_histogram!(
         "example_push_request_duration_seconds",
         "The push request latencies in seconds."
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 fn main() {
     let args: Vec<String> = env::args().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,19 +49,18 @@ You can find more examples within
 # Static Metrics
 
 This crate supports staticly built metrics. You can use it with
-[`lazy_static`](https://docs.rs/lazy_static/) to quickly build up and collect
+[`LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html) to quickly build up and collect
 some metrics.
 
 ```rust
 use prometheus::{self, IntCounter, TextEncoder, Encoder};
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use prometheus::register_int_counter;
 
-lazy_static! {
-    static ref HIGH_FIVE_COUNTER: IntCounter =
-        register_int_counter!("highfives", "Number of high fives received").unwrap();
-}
+static HIGH_FIVE_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| register_int_counter!("highfives", "Number of high fives received").unwrap());
+
 
 HIGH_FIVE_COUNTER.inc();
 assert_eq!(HIGH_FIVE_COUNTER.get(), 1);
@@ -75,14 +74,12 @@ By default, this registers with a default registry. To make a report, you can ca
 # use prometheus::IntCounter;
 use prometheus::{self, TextEncoder, Encoder};
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use prometheus::register_int_counter;
 
 // Register & measure some metrics.
-# lazy_static! {
-#     static ref HIGH_FIVE_COUNTER: IntCounter =
-#        register_int_counter!("highfives", "Number of high fives received").unwrap();
-# }
+# static HIGH_FIVE_COUNTER: LazyLock<IntCounter> =
+#    LazyLock::new(|| register_int_counter!("highfives", "Number of high fives received").unwrap());
 # HIGH_FIVE_COUNTER.inc();
 
 let mut buffer = Vec::new();

--- a/static-metric/README.md
+++ b/static-metric/README.md
@@ -91,7 +91,7 @@ For heavier scenario that a global shared static-metric might not be effecient e
 ```rust
 use prometheus::*;
 
-use lazy_static:lazy_static;
+use std::sync::LazyLock;
 use prometheus_static_metric::{auto_flush_from, make_auto_flush_static_metric};
 
 make_auto_flush_static_metric! {
@@ -118,20 +118,18 @@ make_auto_flush_static_metric! {
     }
 }
 
-lazy_static! {
-    pub static ref HTTP_COUNTER_VEC: IntCounterVec =
-        register_int_counter_vec ! (
-            "http_requests_total",
-            "Number of HTTP requests.",
-            & ["product", "method", "version"]    // it doesn't matter for the label order
-        ).unwrap();
-}
+pub static HTTP_COUNTER_VEC: LazyLock<CounterVec> = LazyLock::new(|| {
+    register_counter_vec!(
+        "http_requests_total",
+        "Number of HTTP requests.",
+        & ["product", "method", "version"]    // it doesn't matter for the label order
+    )
+    .unwrap()
+});
 
-lazy_static! {
-    // You can also use default flush duration which is 1 second.
-    // pub static ref TLS_HTTP_COUNTER: Lhrs = auto_flush_from!(HTTP_COUNTER_VEC, Lhrs);
-    pub static ref TLS_HTTP_COUNTER: Lhrs = auto_flush_from!(HTTP_COUNTER_VEC, Lhrs, std::time::Duration::from_secs(1));
-}
+// You can also use default flush duration which is 1 second.
+// pub static TLS_HTTP_COUNTER: LazyLock<Lhrs> = LazyLock;;new(|| auto_flush_from!(HTTP_COUNTER_VEC, Lhrs));
+pub static TLS_HTTP_COUNTER: LazyLock<Lhrs> = LazyLock::new(|| auto_flush_from!(HTTP_COUNTER_VEC, Lhrs, std::time::Duration::from_secs(1)));
 
 fn main() {
     TLS_HTTP_COUNTER.foo.post.http1.inc();

--- a/static-metric/examples/advanced.rs
+++ b/static-metric/examples/advanced.rs
@@ -1,8 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::LazyLock;
+
 use prometheus::IntCounterVec;
 
-use lazy_static::lazy_static;
 use prometheus::register_int_counter_vec;
 use prometheus_static_metric::make_static_metric;
 
@@ -25,17 +26,17 @@ make_static_metric! {
     }
 }
 
-lazy_static! {
-    pub static ref HTTP_COUNTER_VEC: IntCounterVec =
-        register_int_counter_vec!(
-            "http_requests_total",
-            "Number of HTTP requests.",
-            &["product", "method", "version"]    // it doesn't matter for the label order
-        ).unwrap();
+pub static HTTP_COUNTER_VEC: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "http_requests_total",
+        "Number of HTTP requests.",
+        &["product", "method", "version"] // it doesn't matter for the label order
+    )
+    .unwrap()
+});
 
-    pub static ref HTTP_COUNTER: HttpRequestStatistics = HttpRequestStatistics
-        ::from(&HTTP_COUNTER_VEC);
-}
+pub static HTTP_COUNTER: LazyLock<HttpRequestStatistics> =
+    LazyLock::new(|| HttpRequestStatistics::from(&HTTP_COUNTER_VEC));
 
 /// This example demonstrates the usage of:
 /// 1. using alternative metric types (i.e. IntCounter)

--- a/static-metric/examples/local.rs
+++ b/static-metric/examples/local.rs
@@ -1,10 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::cell::Cell;
+use std::{cell::Cell, sync::LazyLock};
 
 use prometheus::*;
 
-use lazy_static::lazy_static;
 use prometheus_static_metric::make_static_metric;
 
 make_static_metric! {
@@ -28,14 +27,14 @@ make_static_metric! {
     }
 }
 
-lazy_static! {
-    pub static ref HTTP_COUNTER_VEC: IntCounterVec =
-        register_int_counter_vec!(
-            "http_requests_total",
-            "Number of HTTP requests.",
-            &["product", "method", "version"]    // it doesn't matter for the label order
-        ).unwrap();
-}
+pub static HTTP_COUNTER_VEC: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "http_requests_total",
+        "Number of HTTP requests.",
+        &["product", "method", "version"] // it doesn't matter for the label order
+    )
+    .unwrap()
+});
 
 thread_local! {
     static THREAD_LAST_TICK_TIME: Cell<u64> = Cell::new(timer::now_millis());

--- a/static-metric/examples/register_integration.rs
+++ b/static-metric/examples/register_integration.rs
@@ -7,9 +7,10 @@ by using the `register_static_xxx!` macro provided by this crate.
 
 */
 
+use std::sync::LazyLock;
+
 use prometheus::exponential_buckets;
 
-use lazy_static::lazy_static;
 use prometheus::{register_counter_vec, register_histogram_vec};
 use prometheus_static_metric::{
     make_static_metric, register_static_counter_vec, register_static_histogram_vec,
@@ -38,23 +39,25 @@ make_static_metric! {
     }
 }
 
-lazy_static! {
-    pub static ref HTTP_COUNTER: HttpRequestStatistics = register_static_counter_vec!(
+pub static HTTP_COUNTER: LazyLock<HttpRequestStatistics> = LazyLock::new(|| {
+    register_static_counter_vec!(
         HttpRequestStatistics,
         "http_requests_total",
         "Number of HTTP requests.",
         &["method", "product"]
     )
-    .unwrap();
-    pub static ref HTTP_DURATION: HttpRequestDuration = register_static_histogram_vec!(
+    .unwrap()
+});
+pub static HTTP_DURATION: LazyLock<HttpRequestDuration> = LazyLock::new(|| {
+    register_static_histogram_vec!(
         HttpRequestDuration,
         "http_request_duration",
         "Duration of each HTTP request.",
         &["method"],
         exponential_buckets(0.0005, 2.0, 20).unwrap()
     )
-    .unwrap();
-}
+    .unwrap()
+});
 
 fn main() {
     HTTP_COUNTER.post.foo.inc();

--- a/static-metric/examples/with_lazy_static.rs
+++ b/static-metric/examples/with_lazy_static.rs
@@ -1,8 +1,9 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use std::sync::LazyLock;
+
 use prometheus::CounterVec;
 
-use lazy_static::lazy_static;
 use prometheus::register_counter_vec;
 use prometheus_static_metric::make_static_metric;
 
@@ -21,16 +22,16 @@ make_static_metric! {
     }
 }
 
-lazy_static! {
-    pub static ref HTTP_COUNTER_VEC: CounterVec = register_counter_vec!(
+pub static HTTP_COUNTER_VEC: LazyLock<CounterVec> = LazyLock::new(|| {
+    register_counter_vec!(
         "http_requests_total",
         "Number of HTTP requests.",
         &["method", "product"]
     )
-    .unwrap();
-    pub static ref HTTP_COUNTER: HttpRequestStatistics =
-        HttpRequestStatistics::from(&HTTP_COUNTER_VEC);
-}
+    .unwrap()
+});
+pub static HTTP_COUNTER: LazyLock<HttpRequestStatistics> =
+    LazyLock::new(|| HttpRequestStatistics::from(&HTTP_COUNTER_VEC));
 
 fn main() {
     HTTP_COUNTER.post.foo.inc();

--- a/static-metric/src/lib.rs
+++ b/static-metric/src/lib.rs
@@ -8,13 +8,11 @@ This is useful since it reduces the amount of branching and processing needed at
 ```rust
 use prometheus::{self, IntCounter, TextEncoder, Encoder};
 
-use lazy_static::lazy_static;
+use std::sync::LazyLock;
 use prometheus::register_int_counter;
 
-lazy_static! {
-    static ref HIGH_FIVE_COUNTER: IntCounter =
-        register_int_counter!("highfives", "Number of high fives recieved").unwrap();
-}
+static HIGH_FIVE_COUNTER: LazyLock<IntCounter> =
+    LazyLock::new(|| register_int_counter!("highfives", "Number of high fives recieved").unwrap());
 
 HIGH_FIVE_COUNTER.inc();
 assert_eq!(HIGH_FIVE_COUNTER.get(), 1);


### PR DESCRIPTION
Since Rust 1.80, the recommended way to have lazily-initialized statics is to use [`LazyLock`](https://doc.rust-lang.org/std/sync/struct.LazyLock.html).

As this crate's MSRV is 1.81, this PR updates the documentation to encourage that new usage.

This is a change to examples and documentation only.
Once this PR is merged, I'll make another PR updating the internal uses of `lazy_static` within this crate.