### PR TITLE
Add a feature for push with reqwest rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ default = ["protobuf"]
 gen = ["protobuf-codegen"]
 nightly = ["libc"]
 process = ["libc", "procfs"]
-push = ["reqwest", "libc", "protobuf"]
+push = ["dep:reqwest", "libc", "protobuf", "reqwest/default-tls"]
+push-rustls = ["dep:reqwest", "libc", "protobuf", "reqwest/rustls-tls"]
 
 [dependencies]
 cfg-if = "^1.0"
@@ -30,7 +31,7 @@ libc = { version = "^0.2", optional = true }
 parking_lot = "^0.12"
 protobuf = { version = "^3.7.2", optional = true }
 memchr = "^2.3"
-reqwest = { version = "^0.12", features = ["blocking"], optional = true }
+reqwest = { version = "^0.12", features = ["blocking", "charset", "http2", "system-proxy"], default-features = false, optional = true }
 thiserror = "^2.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@ mod histogram;
 mod metrics;
 mod nohash;
 mod pulling_gauge;
-#[cfg(feature = "push")]
+#[cfg(any(feature = "push", feature = "push-rustls"))]
 mod push;
 mod registry;
 mod value;
@@ -211,7 +211,7 @@ pub use self::histogram::{exponential_buckets, linear_buckets};
 pub use self::histogram::{Histogram, HistogramOpts, HistogramTimer, HistogramVec};
 pub use self::metrics::Opts;
 pub use self::pulling_gauge::PullingGauge;
-#[cfg(feature = "push")]
+#[cfg(any(feature = "push", feature = "push-rustls"))]
 pub use self::push::{
     hostname_grouping_key, push_add_collector, push_add_metrics, push_collector, push_metrics,
     BasicAuthentication,


### PR DESCRIPTION
I'm using this crate with "push" feature in an environment that requires boringssl instead of openssl. So my options for tls library are rustls or boring. With the current configuration, adding push feature pulls in reqwest with default features which relies on native-tls and openssl.

This PR is introducing a new feature (push-rustls) that allows push to work with rustls. I explicitly added the default features from reqwest that would be disabled by this change but do not affect the tls compatibility: https://github.com/seanmonstar/reqwest/blob/master/Cargo.toml#L37C27-L37C61