### PR TITLE
Bump rust version requirement to 1.82, because dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,9 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting and benchmarks
-  ACTIONS_LINTS_TOOLCHAIN: 1.81.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.82.0
   # Minimum supported Rust version (MSRV)
-  ACTION_MSRV_TOOLCHAIN: 1.81.0
+  ACTION_MSRV_TOOLCHAIN: 1.82.0
   EXTRA_FEATURES: "protobuf push process"
 
 jobs:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "prometheus"
 readme = "README.md"
 repository = "https://github.com/tikv/rust-prometheus"
-rust-version = "1.81"
+rust-version = "1.82"
 version = "0.14.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This should fix:

```
error: rustc 1.81.0 is not supported by the following packages:
  icu_collections@2.0.0 requires rustc 1.82
  icu_locale_core@2.0.0 requires rustc 1.82
  icu_normalizer@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_normalizer_data@2.0.0 requires rustc 1.82
  icu_properties@2.0.1 requires rustc 1.82
  icu_properties_data@2.0.1 requires rustc 1.82
  icu_properties_data@2.0.1 requires rustc 1.82
  icu_properties_data@2.0.1 requires rustc 1.82
  icu_provider@2.0.0 requires rustc 1.82
  idna_adapter@1.2.1 requires rustc 1.82
  litemap@0.8.0 requires rustc 1.82
  potential_utf@0.1.3 requires rustc 1.82
  zerotrie@0.2.2 requires rustc 1.82
  zerovec@0.11.4 requires rustc 1.82
Either upgrade rustc or select compatible dependency versions with
`cargo update <name>@<current-ver> --precise <compatible-ver>`
where `<compatible-ver>` is the latest version supporting rustc 1.81.0
```